### PR TITLE
typesupport c reloaded

### DIFF
--- a/rosidl_default_generators/package.xml
+++ b/rosidl_default_generators/package.xml
@@ -15,6 +15,7 @@
   <buildtool_export_depend>rosidl_generator_cpp</buildtool_export_depend>
   <buildtool_export_depend>rosidl_generator_py</buildtool_export_depend>
 
+  <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_cpp</buildtool_export_depend>
 
   <buildtool_export_depend>rosidl_typesupport_introspection_c</buildtool_export_depend>

--- a/rosidl_default_generators/rosidl_default_generators-extras.cmake.in
+++ b/rosidl_default_generators/rosidl_default_generators-extras.cmake.in
@@ -2,6 +2,7 @@
 # rosidl_default_generators/rosidl_default_generators-extras.cmake.in
 
 set(_exported_dependencies
+  "rosidl_typesupport_c"
   "rosidl_typesupport_cpp"
   "rosidl_typesupport_introspection_c"
   "rosidl_typesupport_introspection_cpp"

--- a/rosidl_default_runtime/CMakeLists.txt
+++ b/rosidl_default_runtime/CMakeLists.txt
@@ -5,6 +5,7 @@ project(rosidl_default_runtime NONE)
 find_package(ament_cmake REQUIRED)
 
 ament_export_dependencies(rosidl_generator_cpp)
+ament_export_dependencies(rosidl_typesupport_c)
 ament_export_dependencies(rosidl_typesupport_cpp)
 ament_export_dependencies(rosidl_typesupport_introspection_c)
 ament_export_dependencies(rosidl_typesupport_introspection_cpp)

--- a/rosidl_default_runtime/package.xml
+++ b/rosidl_default_runtime/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake</buildtool_depend>
 
   <build_export_depend>rosidl_generator_cpp</build_export_depend>
+  <build_export_depend>rosidl_typesupport_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>

--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -1,0 +1,67 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(rosidl_typesupport_c)
+
+if(NOT WIN32)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c11 -Wall -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
+endif()
+
+find_package(ament_cmake REQUIRED)
+# provides FindPoco.cmake and Poco on platforms without it
+find_package(poco_vendor REQUIRED)
+find_package(Poco REQUIRED COMPONENTS Foundation)
+find_package(rosidl_generator_c REQUIRED)
+
+link_directories(${Poco_LIBRARY_DIR})
+
+ament_export_dependencies(rosidl_typesupport_interface)
+
+ament_export_include_directories(include)
+
+ament_python_install_package(${PROJECT_NAME})
+
+add_library(${PROJECT_NAME} SHARED
+  src/identifier.c
+  src/message_type_support_dispatch.cpp
+  src/service_type_support_dispatch.cpp
+  src/type_support_dispatch.cpp)
+if(WIN32)
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE "ROSIDL_TYPESUPPORT_C_BUILDING_DLL")
+endif()
+target_include_directories(${PROJECT_NAME}
+  PUBLIC
+  include ${Poco_INCLUDE_DIRS}
+)
+target_link_libraries(${PROJECT_NAME} ${Poco_LIBRARIES})
+ament_target_dependencies(${PROJECT_NAME} "rosidl_generator_c")
+ament_export_libraries(${PROJECT_NAME})
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_package(
+  CONFIG_EXTRAS "rosidl_typesupport_c-extras.cmake.in"
+)
+
+install(
+  PROGRAMS bin/rosidl_typesupport_c
+  DESTINATION lib/rosidl_typesupport_c
+)
+install(
+  DIRECTORY cmake resource
+  DESTINATION share/${PROJECT_NAME}
+)
+install(
+  DIRECTORY include/
+  DESTINATION include
+)
+install(
+  TARGETS ${PROJECT_NAME}
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)

--- a/rosidl_typesupport_c/bin/rosidl_typesupport_c
+++ b/rosidl_typesupport_c/bin/rosidl_typesupport_c
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import argparse
+import sys
+
+from rosidl_parser import UnknownMessageType
+from rosidl_typesupport_c import generate_c
+
+
+def main(argv=sys.argv[1:]):
+    parser = argparse.ArgumentParser(
+        description='Generate the C type support to handle ROS messages.',
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter)
+    parser.add_argument(
+        '--generator-arguments-file',
+        required=True,
+        help='The location of the file containing the generator arguments')
+    args = parser.parse_args(argv)
+
+    try:
+        return generate_c(
+            args.generator_arguments_file,
+        )
+    except UnknownMessageType as e:
+        print(str(e), file=sys.stderr)
+        return 1
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/rosidl_typesupport_c/include/rosidl_typesupport_c/identifier.h
+++ b/rosidl_typesupport_c/include/rosidl_typesupport_c/identifier.h
@@ -1,0 +1,32 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_C__IDENTIFIER_H_
+#define ROSIDL_TYPESUPPORT_C__IDENTIFIER_H_
+
+#include "rosidl_typesupport_c/visibility_control.h"
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_C_PUBLIC
+extern const char * rosidl_typesupport_c__typesupport_identifier;
+
+#if __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_TYPESUPPORT_C__IDENTIFIER_H_

--- a/rosidl_typesupport_c/include/rosidl_typesupport_c/message_type_support_dispatch.h
+++ b/rosidl_typesupport_c/include/rosidl_typesupport_c/message_type_support_dispatch.h
@@ -1,0 +1,36 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_C__MESSAGE_TYPE_SUPPORT_DISPATCH_H_
+#define ROSIDL_TYPESUPPORT_C__MESSAGE_TYPE_SUPPORT_DISPATCH_H_
+
+#include "rosidl_generator_c/message_type_support_struct.h"
+
+#include "rosidl_typesupport_c/visibility_control.h"
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_C_PUBLIC
+const rosidl_message_type_support_t *
+rosidl_typesupport_c__get_message_typesupport_handle_function(
+  const rosidl_message_type_support_t * handle, const char * identifier);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_TYPESUPPORT_C__MESSAGE_TYPE_SUPPORT_DISPATCH_H_

--- a/rosidl_typesupport_c/include/rosidl_typesupport_c/service_type_support_dispatch.h
+++ b/rosidl_typesupport_c/include/rosidl_typesupport_c/service_type_support_dispatch.h
@@ -1,0 +1,36 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_C__SERVICE_TYPE_SUPPORT_DISPATCH_H_
+#define ROSIDL_TYPESUPPORT_C__SERVICE_TYPE_SUPPORT_DISPATCH_H_
+
+#include "rosidl_generator_c/service_type_support.h"
+
+#include "rosidl_typesupport_c/visibility_control.h"
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_C_PUBLIC
+const rosidl_service_type_support_t *
+rosidl_typesupport_c__get_service_typesupport_handle_function(
+  const rosidl_service_type_support_t * handle, const char * identifier);
+
+#if __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_TYPESUPPORT_C__SERVICE_TYPE_SUPPORT_DISPATCH_H_

--- a/rosidl_typesupport_c/include/rosidl_typesupport_c/type_support_map.h
+++ b/rosidl_typesupport_c/include/rosidl_typesupport_c/type_support_map.h
@@ -1,0 +1,41 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_C__TYPE_SUPPORT_MAP_H_
+#define ROSIDL_TYPESUPPORT_C__TYPE_SUPPORT_MAP_H_
+
+#include <cstddef>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+typedef struct type_support_map_t
+{
+  // TODO(dirk-thomas) const should not be defined for the fields
+  // but should be set for the struct when it is being used
+  // same for rosidl_message_type_support_t et al
+  const size_t size;
+  const char * package_name;
+  const char * const * typesupport_identifier;
+  const char * const * symbol_name;
+  void ** data;
+} type_support_map_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_TYPESUPPORT_C__TYPE_SUPPORT_MAP_H_

--- a/rosidl_typesupport_c/include/rosidl_typesupport_c/visibility_control.h
+++ b/rosidl_typesupport_c/include/rosidl_typesupport_c/visibility_control.h
@@ -1,0 +1,56 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ROSIDL_TYPESUPPORT_C__VISIBILITY_CONTROL_H_
+#define ROSIDL_TYPESUPPORT_C__VISIBILITY_CONTROL_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TYPESUPPORT_C_EXPORT __attribute__ ((dllexport))
+    #define ROSIDL_TYPESUPPORT_C_IMPORT __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TYPESUPPORT_C_EXPORT __declspec(dllexport)
+    #define ROSIDL_TYPESUPPORT_C_IMPORT __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TYPESUPPORT_C_BUILDING_DLL
+    #define ROSIDL_TYPESUPPORT_C_PUBLIC ROSIDL_TYPESUPPORT_C_EXPORT
+  #else
+    #define ROSIDL_TYPESUPPORT_C_PUBLIC ROSIDL_TYPESUPPORT_C_IMPORT
+  #endif
+  #define ROSIDL_TYPESUPPORT_C_LOCAL
+#else
+  #define ROSIDL_TYPESUPPORT_C_EXPORT __attribute__ ((visibility("default")))
+  #define ROSIDL_TYPESUPPORT_C_IMPORT
+  #if __GNUC__ >= 4
+    #define ROSIDL_TYPESUPPORT_C_PUBLIC __attribute__ ((visibility("default")))
+    #define ROSIDL_TYPESUPPORT_C_LOCAL  __attribute__ ((visibility("hidden")))
+  #else
+    #define ROSIDL_TYPESUPPORT_C_PUBLIC
+    #define ROSIDL_TYPESUPPORT_C_LOCAL
+  #endif
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // ROSIDL_TYPESUPPORT_C__VISIBILITY_CONTROL_H_

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="2">
+  <name>rosidl_typesupport_c</name>
+  <version>0.0.0</version>
+  <description>Generate the type support for C messages.</description>
+  <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+
+  <build_depend>libpoco-dev</build_depend>
+  <build_depend>poco_vendor</build_depend>
+  <build_depend>rosidl_generator_c</build_depend>
+  <build_depend>rosidl_typesupport_connext_c</build_depend>
+  <build_depend>rosidl_typesupport_introspection_c</build_depend>
+  <build_depend>rosidl_typesupport_opensplice_c</build_depend>
+
+  <buildtool_export_depend>ament_index_python</buildtool_export_depend>
+  <build_export_depend>rosidl_generator_c</build_export_depend>
+
+  <exec_depend>libpoco-dev</exec_depend>
+  <exec_depend>poco_vendor</exec_depend>
+  <exec_depend>rosidl_typesupport_interface</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>ament_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -1,0 +1,117 @@
+// generated from rosidl_typesupport_c/resource/msg__type_support.cpp.em
+// generated code does not contain a copyright notice
+
+@#######################################################################
+@# EmPy template for generating <msg>__type_support.cpp files
+@#
+@# Context:
+@#  - spec (rosidl_parser.MessageSpecification)
+@#    Parsed specification of the .msg file
+@#  - subfolder (string)
+@#    The subfolder / subnamespace of the message
+@#    Either 'msg' or 'srv'
+@#  - type_supports (list of strings)
+@#    The name of the type support packages
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
+#include <cstddef>
+
+#include "rosidl_generator_c/message_type_support_struct.h"
+
+#include "@(spec.base_type.pkg_name)/msg/rosidl_typesupport_c__visibility_control.h"
+#include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__struct.h"
+
+#include "rosidl_typesupport_c/identifier.h"
+#include "rosidl_typesupport_c/message_type_support_dispatch.h"
+#include "rosidl_typesupport_c/type_support_map.h"
+#include "rosidl_typesupport_c/visibility_control.h"
+#include "rosidl_typesupport_interface/macros.h"
+
+namespace @(spec.base_type.pkg_name)
+{
+
+namespace @(subfolder)
+{
+
+namespace rosidl_typesupport_c
+{
+
+typedef struct _type_support_ids_t
+{
+  const char * typesupport_identifier[@(len(type_supports))];
+} _type_support_ids_t;
+
+static const _type_support_ids_t _@(spec.base_type.type)_message_typesupport_ids = {
+  {
+@# TODO(dirk-thomas) use identifier symbol again
+@[for type_support in sorted(type_supports)]@
+    "@(type_support)",  // ::@(type_support)::typesupport_identifier,
+@[end for]@
+  }
+};
+
+typedef struct _type_support_symbol_names_t
+{
+  const char * symbol_name[@(len(type_supports))];
+} _type_support_symbol_names_t;
+
+#define STRINGIFY_(s) #s
+#define STRINGIFY(s) STRINGIFY_(s)
+
+static const _type_support_symbol_names_t _@(spec.base_type.type)_message_typesupport_symbol_names = {
+  {
+@[for type_support in sorted(type_supports)]@
+    STRINGIFY(ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(@(type_support), @(spec.base_type.pkg_name), @(subfolder), @(spec.base_type.type))),
+@[end for]@
+  }
+};
+
+typedef struct _type_support_data_t
+{
+  void * data[@(len(type_supports))];
+} _type_support_data_t;
+
+static _type_support_data_t _@(spec.base_type.type)_message_typesupport_data = {
+  {
+@[for type_support in sorted(type_supports)]@
+    0,  // will store the shared library later
+@[end for]@
+  }
+};
+
+static const type_support_map_t _@(spec.base_type.type)_message_typesupport_map = {
+  @(len(type_supports)),
+  "@(spec.base_type.pkg_name)",
+  &_@(spec.base_type.type)_message_typesupport_ids.typesupport_identifier[0],
+  &_@(spec.base_type.type)_message_typesupport_symbol_names.symbol_name[0],
+  &_@(spec.base_type.type)_message_typesupport_data.data[0],
+};
+
+static const rosidl_message_type_support_t @(spec.base_type.type)_message_type_support_handle = {
+  rosidl_typesupport_c__typesupport_identifier,
+  reinterpret_cast<const type_support_map_t *>(&_@(spec.base_type.type)_message_typesupport_map),
+  rosidl_typesupport_c__get_message_typesupport_handle_function,
+};
+
+}  // namespace rosidl_typesupport_c
+
+}  // namespace @(subfolder)
+
+}  // namespace @(spec.base_type.pkg_name)
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_C_EXPORT_@(spec.base_type.pkg_name)
+const rosidl_message_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_c, @(spec.base_type.pkg_name), @(subfolder), @(spec.base_type.type))() {
+  return &::@(spec.base_type.pkg_name)::@(subfolder)::rosidl_typesupport_c::@(spec.base_type.type)_message_type_support_handle;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/rosidl_typesupport_c/resource/rosidl_typesupport_c__visibility_control.h.in
+++ b/rosidl_typesupport_c/resource/rosidl_typesupport_c__visibility_control.h.in
@@ -1,0 +1,43 @@
+// generated from
+// rosidl_typesupport_c/resource/rosidl_typesupport_c__visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_C__VISIBILITY_CONTROL_H_
+#define @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_C__VISIBILITY_CONTROL_H_
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TYPESUPPORT_C_EXPORT_@PROJECT_NAME@ __attribute__ ((dllexport))
+    #define ROSIDL_TYPESUPPORT_C_IMPORT_@PROJECT_NAME@ __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TYPESUPPORT_C_EXPORT_@PROJECT_NAME@ __declspec(dllexport)
+    #define ROSIDL_TYPESUPPORT_C_IMPORT_@PROJECT_NAME@ __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TYPESUPPORT_C_BUILDING_DLL_@PROJECT_NAME@
+    #define ROSIDL_TYPESUPPORT_C_PUBLIC_@PROJECT_NAME@ ROSIDL_TYPESUPPORT_C_EXPORT_@PROJECT_NAME@
+  #else
+    #define ROSIDL_TYPESUPPORT_C_PUBLIC_@PROJECT_NAME@ ROSIDL_TYPESUPPORT_C_IMPORT_@PROJECT_NAME@
+  #endif
+#else
+  #define ROSIDL_TYPESUPPORT_C_EXPORT_@PROJECT_NAME@ __attribute__ ((visibility("default")))
+  #define ROSIDL_TYPESUPPORT_C_IMPORT_@PROJECT_NAME@
+  #if __GNUC__ >= 4
+    #define ROSIDL_TYPESUPPORT_C_PUBLIC_@PROJECT_NAME@ __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_TYPESUPPORT_C_PUBLIC_@PROJECT_NAME@
+  #endif
+#endif
+
+#if __cplusplus
+}
+#endif
+
+#endif  // @PROJECT_NAME_UPPER@__MSG__ROSIDL_TYPESUPPORT_C__VISIBILITY_CONTROL_H_

--- a/rosidl_typesupport_c/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/srv__type_support.cpp.em
@@ -1,0 +1,112 @@
+// generated from rosidl_typesupport_c/resource/srv__type_support.cpp.em
+// generated code does not contain a copyright notice
+
+@#######################################################################
+@# EmPy template for generating <srv>__type_support.cpp files
+@#
+@# Context:
+@#  - spec (rosidl_parser.ServiceSpecification)
+@#    Parsed specification of the .srv file
+@#  - type_supports (list of strings)
+@#    The name of the type support packages
+@#  - get_header_filename_from_msg_name (function)
+@#######################################################################
+@
+#include <cstddef>
+
+#include "rosidl_generator_c/service_type_support.h"
+
+#include "@(spec.pkg_name)/msg/rosidl_typesupport_c__visibility_control.h"
+
+#include "rosidl_typesupport_c/identifier.h"
+#include "rosidl_typesupport_c/service_type_support_dispatch.h"
+#include "rosidl_typesupport_c/type_support_map.h"
+#include "rosidl_typesupport_interface/macros.h"
+
+namespace @(spec.pkg_name)
+{
+
+namespace srv
+{
+
+namespace rosidl_typesupport_c
+{
+
+typedef struct _type_support_ids_t
+{
+  const char * typesupport_identifier[@(len(type_supports))];
+} _type_support_ids_t;
+
+static const _type_support_ids_t _@(spec.srv_name)_service_typesupport_ids = {
+  {
+@# TODO(dirk-thomas) use identifier symbol again
+@[for type_support in sorted(type_supports)]@
+    "@(type_support)",  // ::@(type_support)::typesupport_identifier,
+@[end for]@
+  }
+};
+
+typedef struct _type_support_symbol_names_t
+{
+  const char * symbol_name[@(len(type_supports))];
+} _type_support_symbol_names_t;
+
+#define STRINGIFY_(s) #s
+#define STRINGIFY(s) STRINGIFY_(s)
+
+static const _type_support_symbol_names_t _@(spec.srv_name)_service_typesupport_symbol_names = {
+  {
+@[for type_support in sorted(type_supports)]@
+    STRINGIFY(ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(@(type_support), @(spec.pkg_name), @(spec.srv_name))),
+@[end for]@
+  }
+};
+
+typedef struct _type_support_data_t
+{
+  void * data[@(len(type_supports))];
+} _type_support_data_t;
+
+static _type_support_data_t _@(spec.srv_name)_service_typesupport_data = {
+  {
+@[for type_support in sorted(type_supports)]@
+    0,  // will store the shared library later
+@[end for]@
+  }
+};
+
+static const type_support_map_t _@(spec.srv_name)_service_typesupport_map = {
+  @(len(type_supports)),
+  "@(spec.pkg_name)",
+  &_@(spec.srv_name)_service_typesupport_ids.typesupport_identifier[0],
+  &_@(spec.srv_name)_service_typesupport_symbol_names.symbol_name[0],
+  &_@(spec.srv_name)_service_typesupport_data.data[0],
+};
+
+static const rosidl_service_type_support_t @(spec.srv_name)_service_type_support_handle = {
+  rosidl_typesupport_c__typesupport_identifier,
+  reinterpret_cast<const type_support_map_t *>(&_@(spec.srv_name)_service_typesupport_map),
+  rosidl_typesupport_c__get_service_typesupport_handle_function,
+};
+
+}  // namespace rosidl_typesupport_c
+
+}  // namespace srv
+
+}  // namespace @(spec.pkg_name)
+
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_C_EXPORT_@(spec.pkg_name)
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_c, @(spec.pkg_name), @(spec.srv_name))() {
+  return &::@(spec.pkg_name)::srv::rosidl_typesupport_c::@(spec.srv_name)_service_type_support_handle;
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
+++ b/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
@@ -1,0 +1,23 @@
+# generated from
+# rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
+
+find_package(ament_cmake_core QUIET REQUIRED)
+ament_register_extension(
+  "rosidl_generate_interfaces"
+  "rosidl_typesupport_c"
+  "rosidl_typesupport_c_generate_interfaces.cmake")
+
+set(rosidl_typesupport_c_BIN
+  "${rosidl_typesupport_c_DIR}/../../../lib/rosidl_typesupport_c/rosidl_typesupport_c")
+normalize_path(rosidl_typesupport_c_BIN
+  "${rosidl_typesupport_c_BIN}")
+
+set(rosidl_typesupport_c_GENERATOR_FILES
+  "${rosidl_typesupport_c_DIR}/../../../@PYTHON_INSTALL_DIR@/rosidl_typesupport_c/__init__.py")
+normalize_path(rosidl_typesupport_c_GENERATOR_FILES
+  "${rosidl_typesupport_c_GENERATOR_FILES}")
+
+set(rosidl_typesupport_c_TEMPLATE_DIR
+  "${rosidl_typesupport_c_DIR}/../resource")
+normalize_path(rosidl_typesupport_c_TEMPLATE_DIR
+  "${rosidl_typesupport_c_TEMPLATE_DIR}")

--- a/rosidl_typesupport_c/rosidl_typesupport_c/__init__.py
+++ b/rosidl_typesupport_c/rosidl_typesupport_c/__init__.py
@@ -1,0 +1,88 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+from ament_index_python import get_resources
+from rosidl_cmake import convert_camel_case_to_lower_case_underscore
+from rosidl_cmake import expand_template
+from rosidl_cmake import extract_message_types
+from rosidl_cmake import get_newest_modification_time
+from rosidl_cmake import read_generator_arguments
+from rosidl_parser import parse_message_file
+from rosidl_parser import parse_service_file
+from rosidl_parser import validate_field_types
+
+
+def generate_c(generator_arguments_file):
+    args = read_generator_arguments(generator_arguments_file)
+
+    template_dir = args['template_dir']
+    mapping_msgs = {
+        os.path.join(template_dir, 'msg__type_support.cpp.em'):
+        '%s__type_support.cpp',
+    }
+    mapping_srvs = {
+        os.path.join(template_dir, 'srv__type_support.cpp.em'):
+        '%s__type_support.cpp',
+    }
+
+    for template_file in mapping_msgs.keys():
+        assert os.path.exists(template_file), 'Could not find template: ' + template_file
+
+    for template_file in mapping_srvs.keys():
+        assert os.path.exists(template_file), 'Could not find template: ' + template_file
+
+    pkg_name = args['package_name']
+    known_msg_types = extract_message_types(
+        pkg_name, args['ros_interface_files'], args.get('ros_interface_dependencies', []))
+
+    functions = {
+        'get_header_filename_from_msg_name': convert_camel_case_to_lower_case_underscore,
+    }
+    latest_target_timestamp = get_newest_modification_time(args['target_dependencies'])
+    type_supports = list(get_resources('rosidl_typesupport_c').keys())
+
+    for ros_interface_file in args['ros_interface_files']:
+        extension = os.path.splitext(ros_interface_file)[1]
+        subfolder = os.path.basename(os.path.dirname(ros_interface_file))
+        if extension == '.msg':
+            spec = parse_message_file(pkg_name, ros_interface_file)
+            validate_field_types(spec, known_msg_types)
+            for template_file, generated_filename in mapping_msgs.items():
+                generated_file = os.path.join(
+                    args['output_dir'], subfolder, generated_filename %
+                    convert_camel_case_to_lower_case_underscore(spec.base_type.type))
+
+                data = {'spec': spec, 'subfolder': subfolder, 'type_supports': type_supports}
+                data.update(functions)
+                expand_template(
+                    template_file, data, generated_file,
+                    minimum_timestamp=latest_target_timestamp)
+
+        elif extension == '.srv':
+            spec = parse_service_file(pkg_name, ros_interface_file)
+            validate_field_types(spec, known_msg_types)
+            for template_file, generated_filename in mapping_srvs.items():
+                generated_file = os.path.join(
+                    args['output_dir'], subfolder, generated_filename %
+                    convert_camel_case_to_lower_case_underscore(spec.srv_name))
+
+                data = {'spec': spec, 'type_supports': type_supports}
+                data.update(functions)
+                expand_template(
+                    template_file, data, generated_file,
+                    minimum_timestamp=latest_target_timestamp)
+
+    return 0

--- a/rosidl_typesupport_c/src/identifier.c
+++ b/rosidl_typesupport_c/src/identifier.c
@@ -1,0 +1,18 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rosidl_typesupport_c/visibility_control.h>
+
+ROSIDL_TYPESUPPORT_C_EXPORT
+const char * rosidl_typesupport_c__typesupport_identifier = "rosidl_typesupport_c";

--- a/rosidl_typesupport_c/src/message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/src/message_type_support_dispatch.cpp
@@ -1,0 +1,34 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosidl_typesupport_c/message_type_support_dispatch.h"
+
+#include "type_support_dispatch.hpp"
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+const rosidl_message_type_support_t *
+rosidl_typesupport_c__get_message_typesupport_handle_function(
+  const rosidl_message_type_support_t * handle, const char * identifier)
+{
+  return rosidl_typesupport_c::get_typesupport_handle_function<
+    rosidl_message_type_support_t>(handle, identifier);
+}
+
+#if __cplusplus
+}
+#endif

--- a/rosidl_typesupport_c/src/service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/src/service_type_support_dispatch.cpp
@@ -1,0 +1,34 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "rosidl_typesupport_c/service_type_support_dispatch.h"
+
+#include "type_support_dispatch.hpp"
+
+#if __cplusplus
+extern "C"
+{
+#endif
+
+const rosidl_service_type_support_t *
+rosidl_typesupport_c__get_service_typesupport_handle_function(
+  const rosidl_service_type_support_t * handle, const char * identifier)
+{
+  return rosidl_typesupport_c::get_typesupport_handle_function<
+    rosidl_service_type_support_t>(handle, identifier);
+}
+
+#if __cplusplus
+}
+#endif

--- a/rosidl_typesupport_c/src/type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.cpp
@@ -1,0 +1,102 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "type_support_dispatch.hpp"
+
+#include <list>
+#include <string>
+
+#include <fstream>
+#include <sstream>
+
+namespace rosidl_typesupport_c
+{
+
+std::string find_library_path(const std::string & library_name)
+{
+  const char * env_var;
+  char separator;
+  const char * filename_prefix;
+  const char * filename_extension;
+#ifdef _WIN32
+  env_var = "PATH";
+  separator = ';';
+  filename_prefix = "";
+  filename_extension = ".dll";
+#elif __APPLE__
+  env_var = "DYLD_LIBRARY_PATH";
+  separator = ':';
+  filename_prefix = "lib";
+  filename_extension = ".dylib";
+#else
+  env_var = "LD_LIBRARY_PATH";
+  separator = ':';
+  filename_prefix = "lib";
+  filename_extension = ".so";
+#endif
+  std::string search_path = get_env_var(env_var);
+  std::list<std::string> search_paths = split(search_path, separator);
+
+  std::string filename = filename_prefix;
+  filename += library_name + filename_extension;
+
+  for (auto it : search_paths) {
+    std::string path = it + "/" + filename;
+    if (is_file_exist(path.c_str())) {
+      return path;
+    }
+  }
+  return "";
+}
+
+std::string get_env_var(const char * env_var)
+{
+  char * value = nullptr;
+#ifndef _WIN32
+  value = getenv(env_var);
+#else
+  size_t value_size;
+  _dupenv_s(&value, &value_size, env_var);
+#endif
+  std::string value_str = "";
+  if (value) {
+    value_str = value;
+#ifdef _WIN32
+    free(value);
+#endif
+  }
+  // printf("get_env_var(%s) = %s\n", env_var, value_str.c_str());
+  return value_str;
+}
+
+std::list<std::string> split(const std::string & value, const char delimiter)
+{
+  std::list<std::string> list;
+  std::istringstream ss(value);
+  std::string s;
+  while (std::getline(ss, s, delimiter)) {
+    list.push_back(s);
+  }
+  // printf("split(%s) = %zu\n", value.c_str(), list.size());
+  return list;
+}
+
+bool is_file_exist(const char * filename)
+{
+  std::ifstream h(filename);
+  // printf("is_file_exist(%s) = %s\n", filename, h.good() ? "true" : "false");
+  return h.good();
+}
+
+}  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -1,0 +1,89 @@
+// Copyright 2016 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TYPE_SUPPORT_DISPATCH_HPP_
+#define TYPE_SUPPORT_DISPATCH_HPP_
+
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+
+#include <list>
+#include <string>
+
+#include "Poco/SharedLibrary.h"
+
+#include "rosidl_typesupport_c/identifier.h"
+#include "rosidl_typesupport_c/type_support_map.h"
+
+namespace rosidl_typesupport_c
+{
+
+std::string find_library_path(const std::string & library_name);
+
+std::string get_env_var(const char * env_var);
+
+std::list<std::string> split(const std::string & value, const char delimiter);
+
+bool is_file_exist(const char * filename);
+
+extern const char * typesupport_identifier;
+
+template<typename TypeSupport>
+const TypeSupport *
+get_typesupport_handle_function(
+  const TypeSupport * handle, const char * identifier)
+{
+  if (strcmp(handle->typesupport_identifier, identifier) == 0) {
+    return handle;
+  }
+  if (handle->typesupport_identifier == rosidl_typesupport_c__typesupport_identifier) {
+    const type_support_map_t * map = \
+      static_cast<const type_support_map_t *>(handle->data);
+    for (size_t i = 0; i < map->size; ++i) {
+      if (strcmp(map->typesupport_identifier[i], identifier) != 0) {
+        continue;
+      }
+      Poco::SharedLibrary * lib = nullptr;
+      if (!map->data[i]) {
+        char library_name[1024];
+        snprintf(
+          library_name, 1023, "%s__%s",
+          map->package_name, identifier);
+        std::string library_path = find_library_path(library_name);
+        if (library_path.empty()) {
+          return nullptr;
+        }
+        lib = new Poco::SharedLibrary(library_path);
+        map->data[i] = lib;
+      }
+      auto clib = static_cast<const Poco::SharedLibrary *>(map->data[i]);
+      lib = const_cast<Poco::SharedLibrary *>(clib);
+      if (!lib->hasSymbol(map->symbol_name[i])) {
+        return nullptr;
+      }
+      void * sym = lib->getSymbol(map->symbol_name[i]);
+
+      typedef const TypeSupport * (* funcSignature)(void);
+      funcSignature func = reinterpret_cast<funcSignature>(sym);
+      const TypeSupport * ts = func();
+      return ts;
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace rosidl_typesupport_c
+
+#endif  // TYPE_SUPPORT_DISPATCH_HPP_


### PR DESCRIPTION
Similar to the recent changes to the C++ typesupport this PR together with the many referenced ones applies similar changes to the C typesupport:
* all users of the typesupport always use `rosidl_typesupport_c`
* `rosidl_typesupport_c` stores a dictionary of available typesupports
* the rmw implementation use a function from the typesupport struct to extract the specific typesupport they support

Linux ([![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2131)](http://ci.ros2.org/job/ci_linux/2131/)) and Mac OS ([![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1633)](http://ci.ros2.org/job/ci_osx/1633/)) are looking good. I am still looking into Windows.

But while I am doing that I am already asking for review of this and all referenced PRs (either comment on all linked PRs individually or just here with a note that it covers all PRs).