### PR TITLE
shortcut for single typesupport

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -9,6 +9,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 # provides FindPoco.cmake and Poco on platforms without it
+# TODO(dirk-thomas) make poco optional, if not available only support shortcut later
 find_package(poco_vendor REQUIRED)
 find_package(Poco REQUIRED COMPONENTS Foundation)
 find_package(rosidl_generator_c REQUIRED)

--- a/rosidl_typesupport_c/bin/rosidl_typesupport_c
+++ b/rosidl_typesupport_c/bin/rosidl_typesupport_c
@@ -15,11 +15,17 @@ def main(argv=sys.argv[1:]):
         '--generator-arguments-file',
         required=True,
         help='The location of the file containing the generator arguments')
+    parser.add_argument(
+        '--typesupports',
+        required=True,
+        nargs='+',
+        help='The typesupports to be used')
     args = parser.parse_args(argv)
 
     try:
         return generate_c(
             args.generator_arguments_file,
+            args.typesupports,
         )
     except UnknownMessageType as e:
         print(str(e), file=sys.stderr)

--- a/rosidl_typesupport_c/cmake/get_used_typesupports.cmake
+++ b/rosidl_typesupport_c/cmake/get_used_typesupports.cmake
@@ -1,0 +1,72 @@
+# Copyright 2016 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Get the concrete typesupport names to be used.
+#
+# :param var: the output variable name for the typesupport names
+# :type var: list of strings
+# :param typesupport_type: the type of the typesupport to look for
+# :type typesupport_type: string
+#
+# @public
+#
+function(get_used_typesupports var typesupport_type)
+  ament_index_get_resources(rmw_implementations "rmw_typesupport")
+  if(rmw_implementations STREQUAL "")
+    message(FATAL_ERROR "No RMW implementations found")
+  endif()
+
+  # all type supports available
+  ament_index_get_resources(available_typesupports "${typesupport_type}")
+  if(available_typesupports STREQUAL "")
+    message(FATAL_ERROR "No '${typesupport_type}' found")
+  endif()
+
+  # supported type supports across all rmw implementations
+  set(supported_typesupports "")
+  foreach(rmw_implementation IN LISTS rmw_implementations)
+    ament_index_get_resource(resource "rmw_typesupport" "${rmw_implementation}")
+    foreach(ts IN LISTS resource)
+      if(NOT ts IN_LIST supported_typesupports)
+        list(APPEND supported_typesupports "${ts}")
+      endif()
+    endforeach()
+  endforeach()
+
+  # supported type supports across all rmw implementations which are available
+  set(matching_typesupports "")
+  foreach(ts IN LISTS supported_typesupports)
+    if(ts IN_LIST available_typesupports)
+      list(APPEND matching_typesupports "${ts}")
+    endif()
+  endforeach()
+  list(REMOVE_ITEM matching_typesupports "${typesupport_type}")
+  if(matching_typesupports STREQUAL "")
+    message(FATAL_ERROR "No '${typesupport_type}' found for the following "
+      "rmw implementations: ${rmw_implementations}")
+  endif()
+
+  # if across all available rmw implementation only one type support is supported
+  # then return only that one which will ignore all other available
+  # and enable to bypass the dynamic dispatch
+  list(LENGTH matching_typesupports count)
+  if(count EQUAL 1)
+    message(STATUS "Using single matching ${typesupport_type}: ${matching_typesupports}")
+    set(${var} "${matching_typesupports}" PARENT_SCOPE)
+  else()
+    message(STATUS "Using all available ${typesupport_type}: ${available_typesupports}")
+    set(${var} "${available_typesupports}" PARENT_SCOPE)
+  endif()
+endfunction()

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -67,10 +67,12 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
+get_used_typesupports(typesupports "rosidl_typesupport_c")
 add_custom_command(
   OUTPUT ${_generated_files}
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_c_BIN}
   --generator-arguments-file "${generator_arguments_file}"
+  --typesupports ${typesupports}
   DEPENDS ${target_dependencies}
   COMMENT "Generating C type support dispatch for ROS interfaces"
   VERBATIM
@@ -109,6 +111,17 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 )
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c)
+
+# if only a single typesupport is used this package will directly reference it
+# therefore it needs to link against the selected typesupport
+if(NOT typesupports MATCHES ";")
+  target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PUBLIC
+    "${CMAKE_CURRENT_BINARY_DIR}/${typesupports}")
+  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${rosidl_generate_interfaces_TARGET}__${typesupports})
+endif()
+
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   "rosidl_generator_c"
   "rosidl_typesupport_c"

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -12,12 +12,13 @@
   <build_depend>libpoco-dev</build_depend>
   <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
-  <build_depend>rosidl_typesupport_connext_c</build_depend>
-  <build_depend>rosidl_typesupport_introspection_c</build_depend>
-  <build_depend>rosidl_typesupport_opensplice_c</build_depend>
 
-  <buildtool_export_depend>ament_index_python</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+  <build_export_depend>rmw_implementation</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_connext_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_opensplice_c</build_export_depend>
 
   <exec_depend>libpoco-dev</exec_depend>
   <exec_depend>poco_vendor</exec_depend>

--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -22,12 +22,17 @@
 #include "@(spec.base_type.pkg_name)/msg/rosidl_typesupport_c__visibility_control.h"
 #include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__struct.h"
 
+@[if len(type_supports) != 1]@
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/message_type_support_dispatch.h"
 #include "rosidl_typesupport_c/type_support_map.h"
+@[end if]@
 #include "rosidl_typesupport_c/visibility_control.h"
+@[if len(type_supports) != 1]@
 #include "rosidl_typesupport_interface/macros.h"
+@[end if]@
 
+@[if len(type_supports) != 1]@
 namespace @(spec.base_type.pkg_name)
 {
 
@@ -100,7 +105,10 @@ static const rosidl_message_type_support_t @(spec.base_type.type)_message_type_s
 
 }  // namespace @(spec.base_type.pkg_name)
 
+@[else]@
+#include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__@(list(type_supports)[0]).h"
 
+@[end if]@
 #ifdef __cplusplus
 extern "C"
 {
@@ -109,7 +117,11 @@ extern "C"
 ROSIDL_TYPESUPPORT_C_EXPORT_@(spec.base_type.pkg_name)
 const rosidl_message_type_support_t *
 ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(rosidl_typesupport_c, @(spec.base_type.pkg_name), @(subfolder), @(spec.base_type.type))() {
+@[if len(type_supports) != 1]@
   return &::@(spec.base_type.pkg_name)::@(subfolder)::rosidl_typesupport_c::@(spec.base_type.type)_message_type_support_handle;
+@[else]@
+  return ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(@(list(type_supports)[0]), @(spec.base_type.pkg_name), @(subfolder), @(spec.base_type.type))();
+@[end if]@
 }
 
 #ifdef __cplusplus

--- a/rosidl_typesupport_c/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/srv__type_support.cpp.em
@@ -18,11 +18,14 @@
 
 #include "@(spec.pkg_name)/msg/rosidl_typesupport_c__visibility_control.h"
 
+@[if len(type_supports) != 1]@
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/service_type_support_dispatch.h"
 #include "rosidl_typesupport_c/type_support_map.h"
+@[end if]@
 #include "rosidl_typesupport_interface/macros.h"
 
+@[if len(type_supports) != 1]@
 namespace @(spec.pkg_name)
 {
 
@@ -95,7 +98,10 @@ static const rosidl_service_type_support_t @(spec.srv_name)_service_type_support
 
 }  // namespace @(spec.pkg_name)
 
+@[else]@
+#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__@(list(type_supports)[0]).h"
 
+@[end if]@
 #ifdef __cplusplus
 extern "C"
 {
@@ -104,7 +110,11 @@ extern "C"
 ROSIDL_TYPESUPPORT_C_EXPORT_@(spec.pkg_name)
 const rosidl_service_type_support_t *
 ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_c, @(spec.pkg_name), @(spec.srv_name))() {
+@[if len(type_supports) != 1]@
   return &::@(spec.pkg_name)::srv::rosidl_typesupport_c::@(spec.srv_name)_service_type_support_handle;
+@[else]@
+  return ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(@(list(type_supports)[0]), @(spec.pkg_name), @(spec.srv_name))();
+@[end if]@
 }
 
 #ifdef __cplusplus

--- a/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
+++ b/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
@@ -2,6 +2,9 @@
 # rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
 
 find_package(ament_cmake_core QUIET REQUIRED)
+
+include("${rosidl_typesupport_c_DIR}/get_used_typesupports.cmake")
+
 ament_register_extension(
   "rosidl_generate_interfaces"
   "rosidl_typesupport_c"

--- a/rosidl_typesupport_c/rosidl_typesupport_c/__init__.py
+++ b/rosidl_typesupport_c/rosidl_typesupport_c/__init__.py
@@ -14,7 +14,6 @@
 
 import os
 
-from ament_index_python import get_resources
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 from rosidl_cmake import expand_template
 from rosidl_cmake import extract_message_types
@@ -25,7 +24,7 @@ from rosidl_parser import parse_service_file
 from rosidl_parser import validate_field_types
 
 
-def generate_c(generator_arguments_file):
+def generate_c(generator_arguments_file, type_supports):
     args = read_generator_arguments(generator_arguments_file)
 
     template_dir = args['template_dir']
@@ -52,7 +51,6 @@ def generate_c(generator_arguments_file):
         'get_header_filename_from_msg_name': convert_camel_case_to_lower_case_underscore,
     }
     latest_target_timestamp = get_newest_modification_time(args['target_dependencies'])
-    type_supports = list(get_resources('rosidl_typesupport_c').keys())
 
     for ros_interface_file in args['ros_interface_files']:
         extension = os.path.splitext(ros_interface_file)[1]

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 # provides FindPoco.cmake and Poco on platforms without it
+# TODO(dirk-thomas) make poco optional, if not available only support shortcut later
 find_package(poco_vendor REQUIRED)
 find_package(Poco REQUIRED COMPONENTS Foundation)
 find_package(rosidl_generator_c REQUIRED)
@@ -15,6 +16,7 @@ find_package(rosidl_generator_c REQUIRED)
 link_directories(${Poco_LIBRARY_DIR})
 
 ament_export_dependencies(rosidl_typesupport_interface)
+ament_export_dependencies(rosidl_typesupport_c)
 
 ament_export_include_directories(include)
 

--- a/rosidl_typesupport_cpp/bin/rosidl_typesupport_cpp
+++ b/rosidl_typesupport_cpp/bin/rosidl_typesupport_cpp
@@ -15,11 +15,17 @@ def main(argv=sys.argv[1:]):
         '--generator-arguments-file',
         required=True,
         help='The location of the file containing the generator arguments')
+    parser.add_argument(
+        '--typesupports',
+        required=True,
+        nargs='+',
+        help='The typesupports to be used')
     args = parser.parse_args(argv)
 
     try:
         return generate_cpp(
             args.generator_arguments_file,
+            args.typesupports,
         )
     except UnknownMessageType as e:
         print(str(e), file=sys.stderr)

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -67,10 +67,12 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
+get_used_typesupports(typesupports "rosidl_typesupport_cpp")
 add_custom_command(
   OUTPUT ${_generated_files}
   COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_cpp_BIN}
   --generator-arguments-file "${generator_arguments_file}"
+  --typesupports ${typesupports}
   DEPENDS ${target_dependencies}
   COMMENT "Generating C++ type support dispatch for ROS interfaces"
   VERBATIM
@@ -95,6 +97,17 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   PUBLIC
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
 )
+
+# if only a single typesupport is used this package will directly reference it
+# therefore it needs to link against the selected typesupport
+if(NOT typesupports MATCHES ";")
+  target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PUBLIC
+    "${CMAKE_CURRENT_BINARY_DIR}/${typesupports}")
+  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    ${rosidl_generate_interfaces_TARGET}__${typesupports})
+endif()
+
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   "rosidl_generator_c"
   "rosidl_generator_cpp"

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -12,12 +12,14 @@
   <build_depend>libpoco-dev</build_depend>
   <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
-  <build_depend>rosidl_typesupport_connext_cpp</build_depend>
-  <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
-  <build_depend>rosidl_typesupport_opensplice_cpp</build_depend>
 
-  <buildtool_export_depend>ament_index_python</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+  <build_export_depend>rmw_implementation</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_c</build_export_depend>
+  <build_export_depend>rosidl_typesupport_connext_cpp</build_export_depend>
+  <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
+  <build_export_depend>rosidl_typesupport_opensplice_cpp</build_export_depend>
 
   <exec_depend>libpoco-dev</exec_depend>
   <exec_depend>poco_vendor</exec_depend>

--- a/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
@@ -21,13 +21,20 @@
 
 #include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__struct.hpp"
 
+@[if len(type_supports) != 1]@
 #include "rosidl_typesupport_cpp/identifier.hpp"
+@[end if]@
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
+@[if len(type_supports) != 1]@
 #include "rosidl_typesupport_cpp/message_type_support_dispatch.hpp"
 #include "rosidl_typesupport_cpp/type_support_map.h"
+@[end if]@
 #include "rosidl_typesupport_cpp/visibility_control.h"
+@[if len(type_supports) != 1]@
 #include "rosidl_typesupport_interface/macros.h"
+@[end if]@
 
+@[if len(type_supports) != 1]@
 namespace @(spec.base_type.pkg_name)
 {
 
@@ -100,7 +107,10 @@ static const rosidl_message_type_support_t @(spec.base_type.type)_message_type_s
 
 }  // namespace @(spec.base_type.pkg_name)
 
+@[else]@
+#include "@(spec.base_type.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.base_type.type))__@(list(type_supports)[0]).hpp"
 
+@[end if]@
 namespace rosidl_typesupport_cpp
 {
 
@@ -109,7 +119,11 @@ ROSIDL_TYPESUPPORT_CPP_PUBLIC
 const rosidl_message_type_support_t *
 get_message_type_support_handle<@(spec.base_type.pkg_name)::@(subfolder)::@(spec.base_type.type)>()
 {
+@[if len(type_supports) != 1]@
   return &::@(spec.base_type.pkg_name)::@(subfolder)::rosidl_typesupport_cpp::@(spec.base_type.type)_message_type_support_handle;
+@[else]@
+  return ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(@(list(type_supports)[0]), @(spec.base_type.pkg_name), @(subfolder), @(spec.base_type.type))();
+@[end if]@
 }
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
@@ -18,13 +18,20 @@
 
 #include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__struct.hpp"
 
+@[if len(type_supports) != 1]@
 #include "rosidl_typesupport_cpp/identifier.hpp"
+@[end if]@
 #include "rosidl_typesupport_cpp/service_type_support.hpp"
+@[if len(type_supports) != 1]@
 #include "rosidl_typesupport_cpp/service_type_support_dispatch.hpp"
 #include "rosidl_typesupport_cpp/type_support_map.h"
+@[end if]@
 #include "rosidl_typesupport_cpp/visibility_control.h"
+@[if len(type_supports) != 1]@
 #include "rosidl_typesupport_interface/macros.h"
+@[end if]@
 
+@[if len(type_supports) != 1]@
 namespace @(spec.pkg_name)
 {
 
@@ -97,7 +104,10 @@ static const rosidl_service_type_support_t @(spec.srv_name)_service_type_support
 
 }  // namespace @(spec.pkg_name)
 
+@[else]@
+#include "@(spec.pkg_name)/srv/@(get_header_filename_from_msg_name(spec.srv_name))__@(list(type_supports)[0]).hpp"
 
+@[end if]@
 namespace rosidl_typesupport_cpp
 {
 
@@ -106,7 +116,11 @@ ROSIDL_TYPESUPPORT_CPP_PUBLIC
 const rosidl_service_type_support_t *
 get_service_type_support_handle<@(spec.pkg_name)::srv::@(spec.srv_name)>()
 {
+@[if len(type_supports) != 1]@
   return &::@(spec.pkg_name)::srv::rosidl_typesupport_cpp::@(spec.srv_name)_service_type_support_handle;
+@[else]@
+  return ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(@(list(type_supports)[0]), @(spec.pkg_name), @(spec.srv_name))();
+@[end if]@
 }
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
@@ -2,6 +2,7 @@
 # rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
 
 find_package(ament_cmake_core QUIET REQUIRED)
+
 ament_register_extension(
   "rosidl_generate_interfaces"
   "rosidl_typesupport_cpp"

--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp/__init__.py
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp/__init__.py
@@ -14,7 +14,6 @@
 
 import os
 
-from ament_index_python import get_resources
 from rosidl_cmake import convert_camel_case_to_lower_case_underscore
 from rosidl_cmake import expand_template
 from rosidl_cmake import extract_message_types
@@ -25,7 +24,7 @@ from rosidl_parser import parse_service_file
 from rosidl_parser import validate_field_types
 
 
-def generate_cpp(generator_arguments_file):
+def generate_cpp(generator_arguments_file, type_supports):
     args = read_generator_arguments(generator_arguments_file)
 
     template_dir = args['template_dir']
@@ -52,7 +51,6 @@ def generate_cpp(generator_arguments_file):
         'get_header_filename_from_msg_name': convert_camel_case_to_lower_case_underscore,
     }
     latest_target_timestamp = get_newest_modification_time(args['target_dependencies'])
-    type_supports = list(get_resources('rosidl_typesupport_cpp').keys())
 
     for ros_interface_file in args['ros_interface_files']:
         extension = os.path.splitext(ros_interface_file)[1]


### PR DESCRIPTION
If all available rmw implementation use the same typesupport (which should "always" be the case for a single rmw implementation) `rosidl_typesupport_c|cpp` uses that specific typesupport directly (including linking against the specific typesupport) instead of generating a dictionary and dispatching to the requested typesupport at runtime (using `dlopen`).

Only FastRTPS:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2166)](http://ci.ros2.org/job/ci_linux/2166/)
* Mac OS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1649)](http://ci.ros2.org/job/ci_osx/1649/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2169)](http://ci.ros2.org/job/ci_windows/2169/)

Only Connext:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2167)](http://ci.ros2.org/job/ci_linux/2167/)
* Mac OS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1652)](http://ci.ros2.org/job/ci_osx/1652/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2170)](http://ci.ros2.org/job/ci_windows/2170/)

Both:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2168)](http://ci.ros2.org/job/ci_linux/2168/)
* Mac OS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1651)](http://ci.ros2.org/job/ci_osx/1651/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2171)](http://ci.ros2.org/job/ci_windows/2171/)

See ros2/ros2#302