### PR TITLE
make poco optional

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -9,9 +9,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 # provides FindPoco.cmake and Poco on platforms without it
-# TODO(dirk-thomas) make poco optional, if not available only support shortcut later
-find_package(poco_vendor REQUIRED)
-find_package(Poco REQUIRED COMPONENTS Foundation)
+find_package(poco_vendor)
+find_package(Poco COMPONENTS Foundation)
 find_package(rosidl_generator_c REQUIRED)
 
 link_directories(${Poco_LIBRARY_DIR})
@@ -27,6 +26,10 @@ add_library(${PROJECT_NAME} SHARED
   src/message_type_support_dispatch.cpp
   src/service_type_support_dispatch.cpp
   src/type_support_dispatch.cpp)
+if(Poco_FOUND)
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE "ROSIDL_TYPESUPPORT_C_USE_POCO")
+endif()
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_C_BUILDING_DLL")

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -120,6 +120,9 @@ if(NOT typesupports MATCHES ";")
     "${CMAKE_CURRENT_BINARY_DIR}/${typesupports}")
   target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}__${typesupports})
+elseif(NOT rosidl_typesupport_c_SUPPORTS_POCO)
+  message(FATAL_ERROR "Multiple typesupports but Poco was not available when "
+    "rosidl_typesupport_c was built")
 endif()
 
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
+++ b/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
@@ -10,6 +10,8 @@ ament_register_extension(
   "rosidl_typesupport_c"
   "rosidl_typesupport_c_generate_interfaces.cmake")
 
+set(rosidl_typesupport_c_SUPPORTS_POCO @Poco_FOUND@)
+
 set(rosidl_typesupport_c_BIN
   "${rosidl_typesupport_c_DIR}/../../../lib/rosidl_typesupport_c/rosidl_typesupport_c")
 normalize_path(rosidl_typesupport_c_BIN

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -22,7 +22,9 @@
 #include <list>
 #include <string>
 
+#ifdef ROSIDL_TYPESUPPORT_C_USE_POCO
 #include "Poco/SharedLibrary.h"
+#endif
 
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/type_support_map.h"
@@ -48,6 +50,8 @@ get_typesupport_handle_function(
   if (strcmp(handle->typesupport_identifier, identifier) == 0) {
     return handle;
   }
+
+#ifdef ROSIDL_TYPESUPPORT_C_USE_POCO
   if (handle->typesupport_identifier == rosidl_typesupport_c__typesupport_identifier) {
     const type_support_map_t * map = \
       static_cast<const type_support_map_t *>(handle->data);
@@ -81,6 +85,8 @@ get_typesupport_handle_function(
       return ts;
     }
   }
+#endif
+
   return nullptr;
 }
 

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -8,9 +8,8 @@ endif()
 
 find_package(ament_cmake REQUIRED)
 # provides FindPoco.cmake and Poco on platforms without it
-# TODO(dirk-thomas) make poco optional, if not available only support shortcut later
-find_package(poco_vendor REQUIRED)
-find_package(Poco REQUIRED COMPONENTS Foundation)
+find_package(poco_vendor)
+find_package(Poco COMPONENTS Foundation)
 find_package(rosidl_generator_c REQUIRED)
 
 link_directories(${Poco_LIBRARY_DIR})
@@ -27,6 +26,10 @@ add_library(${PROJECT_NAME} SHARED
   src/message_type_support_dispatch.cpp
   src/service_type_support_dispatch.cpp
   src/type_support_dispatch.cpp)
+if(Poco_FOUND)
+  target_compile_definitions(${PROJECT_NAME}
+    PRIVATE "ROSIDL_TYPESUPPORT_CPP_USE_POCO")
+endif()
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_CPP_BUILDING_DLL")

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -106,6 +106,9 @@ if(NOT typesupports MATCHES ";")
     "${CMAKE_CURRENT_BINARY_DIR}/${typesupports}")
   target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}__${typesupports})
+elseif(NOT rosidl_typesupport_cpp_SUPPORTS_POCO)
+  message(FATAL_ERROR "Multiple typesupports but Poco was not available when "
+    "rosidl_typesupport_cpp was built")
 endif()
 
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
@@ -8,6 +8,8 @@ ament_register_extension(
   "rosidl_typesupport_cpp"
   "rosidl_typesupport_cpp_generate_interfaces.cmake")
 
+set(rosidl_typesupport_cpp_SUPPORTS_POCO @Poco_FOUND@)
+
 set(rosidl_typesupport_cpp_BIN
   "${rosidl_typesupport_cpp_DIR}/../../../lib/rosidl_typesupport_cpp/rosidl_typesupport_cpp")
 normalize_path(rosidl_typesupport_cpp_BIN

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -22,7 +22,9 @@
 #include <list>
 #include <string>
 
+#ifdef ROSIDL_TYPESUPPORT_CPP_USE_POCO
 #include "Poco/SharedLibrary.h"
+#endif
 
 #include "rosidl_typesupport_cpp/type_support_map.h"
 
@@ -47,6 +49,8 @@ get_typesupport_handle_function(
   if (strcmp(handle->typesupport_identifier, identifier) == 0) {
     return handle;
   }
+
+#ifdef ROSIDL_TYPESUPPORT_CPP_USE_POCO
   if (handle->typesupport_identifier == rosidl_typesupport_cpp::typesupport_identifier) {
     const type_support_map_t * map = \
       static_cast<const type_support_map_t *>(handle->data);
@@ -80,6 +84,8 @@ get_typesupport_handle_function(
       return ts;
     }
   }
+#endif
+
   return nullptr;
 }
 


### PR DESCRIPTION
If Poco is not available the rosidl_typesupport_c|cpp libraries are being built without it. Downstream interface packages can then only be built if they select a single typesupport.

Only FastRTPS:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2174)](http://ci.ros2.org/job/ci_linux/2174/)
* Mac OS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1656)](http://ci.ros2.org/job/ci_osx/1656/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2176)](http://ci.ros2.org/job/ci_windows/2176/)

Only Connext:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2175)](http://ci.ros2.org/job/ci_linux/2175/)
* Mac OS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1657)](http://ci.ros2.org/job/ci_osx/1657/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2177)](http://ci.ros2.org/job/ci_windows/2177/)

Both:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=2176)](http://ci.ros2.org/job/ci_linux/2176/)
* Mac OS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=1658)](http://ci.ros2.org/job/ci_osx/1658/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=2178)](http://ci.ros2.org/job/ci_windows/2178/)

See ros2/ros2#302