### PR TITLE
Bail out if there is more than one typesupport but the user requests libraries to be built statically

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -7,7 +7,7 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wpedantic")
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 # provides FindPoco.cmake and Poco on platforms without it
 find_package(poco_vendor)
 find_package(Poco COMPONENTS Foundation)

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -113,7 +113,7 @@ target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c)
 
 if(typesupports MATCHES ";")
-  if(NOT BUILD_SHARED_LIBS)
+  if(DEFINED BUILD_SHARED_LIBS AND NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR "Multiple typesupports but static linking was requested")
   endif()
   if(NOT rosidl_typesupport_c_SUPPORTS_POCO)

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -112,17 +112,21 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c)
 
+if(typesupports MATCHES ";")
+  if(NOT BUILD_SHARED_LIBS)
+    message(FATAL_ERROR "Multiple typesupports but static linking was requested")
+  elseif(NOT rosidl_typesupport_c_SUPPORTS_POCO)
+    message(FATAL_ERROR "Multiple typesupports but Poco was not available when "
+      "rosidl_typesupport_c was built")
+  endif()
 # if only a single typesupport is used this package will directly reference it
 # therefore it needs to link against the selected typesupport
-if(NOT typesupports MATCHES ";")
+else()
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PUBLIC
     "${CMAKE_CURRENT_BINARY_DIR}/${typesupports}")
   target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}__${typesupports})
-elseif(NOT rosidl_typesupport_c_SUPPORTS_POCO)
-  message(FATAL_ERROR "Multiple typesupports but Poco was not available when "
-    "rosidl_typesupport_c was built")
 endif()
 
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -115,7 +115,8 @@ target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 if(typesupports MATCHES ";")
   if(NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR "Multiple typesupports but static linking was requested")
-  elseif(NOT rosidl_typesupport_c_SUPPORTS_POCO)
+  endif()
+  if(NOT rosidl_typesupport_c_SUPPORTS_POCO)
     message(FATAL_ERROR "Multiple typesupports but Poco was not available when "
       "rosidl_typesupport_c was built")
   endif()

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -14,7 +14,6 @@
   <build_depend>rosidl_generator_c</build_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
-  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <build_export_depend>rmw_implementation</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_connext_c</build_export_depend>

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -7,13 +7,14 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>libpoco-dev</build_depend>
   <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <build_export_depend>rmw_implementation</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_connext_c</build_export_depend>

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -6,7 +6,7 @@ if(NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra -Wpedantic")
 endif()
 
-find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_ros REQUIRED)
 # provides FindPoco.cmake and Poco on platforms without it
 find_package(poco_vendor)
 find_package(Poco COMPONENTS Foundation)

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -101,7 +101,8 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 if(typesupports MATCHES ";")
   if(NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR "Multiple typesupports but static linking was requested")
-  elseif(NOT rosidl_typesupport_cpp_SUPPORTS_POCO)
+  endif()
+  if(NOT rosidl_typesupport_cpp_SUPPORTS_POCO)
     message(FATAL_ERROR "Multiple typesupports but Poco was not available when "
       "rosidl_typesupport_cpp was built")
   endif()

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -99,7 +99,7 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 )
 
 if(typesupports MATCHES ";")
-  if(NOT BUILD_SHARED_LIBS)
+  if(DEFINED BUILD_SHARED_LIBS AND NOT BUILD_SHARED_LIBS)
     message(FATAL_ERROR "Multiple typesupports but static linking was requested")
   endif()
   if(NOT rosidl_typesupport_cpp_SUPPORTS_POCO)

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -98,17 +98,21 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
 )
 
+if(typesupports MATCHES ";")
+  if(NOT BUILD_SHARED_LIBS)
+    message(FATAL_ERROR "Multiple typesupports but static linking was requested")
+  elseif(NOT rosidl_typesupport_cpp_SUPPORTS_POCO)
+    message(FATAL_ERROR "Multiple typesupports but Poco was not available when "
+      "rosidl_typesupport_cpp was built")
+  endif()
 # if only a single typesupport is used this package will directly reference it
 # therefore it needs to link against the selected typesupport
-if(NOT typesupports MATCHES ";")
+else()
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PUBLIC
     "${CMAKE_CURRENT_BINARY_DIR}/${typesupports}")
   target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}__${typesupports})
-elseif(NOT rosidl_typesupport_cpp_SUPPORTS_POCO)
-  message(FATAL_ERROR "Multiple typesupports but Poco was not available when "
-    "rosidl_typesupport_cpp was built")
 endif()
 
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -7,13 +7,14 @@
   <maintainer email="dthomas@osrfoundation.org">Dirk Thomas</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <build_depend>libpoco-dev</build_depend>
   <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
+  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <build_export_depend>rmw_implementation</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_c</build_export_depend>

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -14,7 +14,6 @@
   <build_depend>rosidl_generator_c</build_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
-  <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <build_export_depend>rmw_implementation</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_c</build_export_depend>


### PR DESCRIPTION
See https://github.com/ros2/rosidl/pull/183#issuecomment-289164782

Connects to https://github.com/ros2/ros2/issues/306