### PR TITLE
add group_depends for typesupport

### DIFF
--- a/rosidl_default_generators/CMakeLists.txt
+++ b/rosidl_default_generators/CMakeLists.txt
@@ -4,6 +4,7 @@ project(rosidl_default_generators NONE)
 
 find_package(ament_cmake REQUIRED)
 
+ament_export_dependencies(ament_cmake_core)
 ament_export_dependencies(rosidl_cmake)
 
 ament_export_dependencies(rosidl_generator_c)

--- a/rosidl_default_generators/package.xml
+++ b/rosidl_default_generators/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rosidl_default_generators</name>
   <version>0.4.0</version>
   <description>A configuration package defining the default ROS interface generators.</description>
@@ -18,6 +18,8 @@
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_cpp</buildtool_export_depend>
 
+  <group_depend>rosidl_typesupport_c_packages</group_depend>
+  <group_depend>rosidl_typesupport_cpp_packages</group_depend>
   <buildtool_export_depend>rosidl_typesupport_introspection_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_introspection_cpp</buildtool_export_depend>
 

--- a/rosidl_default_generators/package.xml
+++ b/rosidl_default_generators/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
 
   <buildtool_export_depend>rosidl_generator_c</buildtool_export_depend>

--- a/rosidl_default_generators/rosidl_default_generators-extras.cmake.in
+++ b/rosidl_default_generators/rosidl_default_generators-extras.cmake.in
@@ -1,15 +1,14 @@
 # generated from
 # rosidl_default_generators/rosidl_default_generators-extras.cmake.in
 
+find_package(ament_cmake_core REQUIRED)
+ament_index_get_resources(rosidl_typesupport_c_packages "rosidl_typesupport_c")
+ament_index_get_resources(rosidl_typesupport_cpp_packages "rosidl_typesupport_cpp")
 set(_exported_dependencies
   "rosidl_typesupport_c"
   "rosidl_typesupport_cpp"
-  "rosidl_typesupport_introspection_c"
-  "rosidl_typesupport_introspection_cpp"
-  "rosidl_typesupport_connext_c"
-  "rosidl_typesupport_connext_cpp"
-  "rosidl_typesupport_opensplice_c"
-  "rosidl_typesupport_opensplice_cpp"
+  ${rosidl_typesupport_c_packages}
+  ${rosidl_typesupport_cpp_packages}
 )
 
 # find_package() all dependencies (if available)

--- a/rosidl_default_runtime/package.xml
+++ b/rosidl_default_runtime/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rosidl_default_runtime</name>
   <version>0.4.0</version>
   <description>A configuration package defining the runtime for the ROS interfaces.</description>
@@ -17,6 +17,8 @@
   <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
 
+  <group_depend>rosidl_typesupport_c_packages</group_depend>
+  <group_depend>rosidl_typesupport_cpp_packages</group_depend>
   <!-- These two dependencies cannot stay here. -->
   <!-- This is a workaround for: https://github.com/ros2/ros2/issues/174 -->
   <!-- Once that issue is properly resolved this needs to be removed. -->

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rosidl_typesupport_c</name>
   <version>0.4.0</version>
   <description>Generate the type support for C messages.</description>
@@ -16,6 +16,8 @@
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <build_export_depend>rmw_implementation</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
+
+  <group_depend>rosidl_typesupport_c_packages</group_depend>
   <build_export_depend>rosidl_typesupport_connext_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_opensplice_c</build_export_depend>

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
-<?xml-model href="http://download.ros.org/schema/package_format2.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
-<package format="2">
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
   <name>rosidl_typesupport_cpp</name>
   <version>0.4.0</version>
   <description>Generate the type support for C++ messages.</description>
@@ -17,6 +17,8 @@
   <build_export_depend>rmw_implementation</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_c</build_export_depend>
+
+  <group_depend>rosidl_typesupport_cpp_packages</group_depend>
   <build_export_depend>rosidl_typesupport_connext_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
   <build_export_depend>rosidl_typesupport_opensplice_cpp</build_export_depend>


### PR DESCRIPTION
Add group dependencies on typesupport packages to make it easier to add additional rmw implementations to a workspace.

Since these PRs only touch the manifests I only triggered a single CI build:
* Linux [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4212)](https://ci.ros2.org/job/ci_linux/4212/)