### PR TITLE
add and use groups for generator and runtime packages

### DIFF
--- a/rosidl_default_generators/CMakeLists.txt
+++ b/rosidl_default_generators/CMakeLists.txt
@@ -7,10 +7,6 @@ find_package(ament_cmake REQUIRED)
 ament_export_dependencies(ament_cmake_core)
 ament_export_dependencies(rosidl_cmake)
 
-ament_export_dependencies(rosidl_generator_c)
-ament_export_dependencies(rosidl_generator_cpp)
-ament_export_dependencies(rosidl_generator_py)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/rosidl_default_generators/package.xml
+++ b/rosidl_default_generators/package.xml
@@ -19,6 +19,7 @@
   <buildtool_export_depend>rosidl_typesupport_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_cpp</buildtool_export_depend>
 
+  <group_depend>rosidl_generator_packages</group_depend>
   <group_depend>rosidl_typesupport_c_packages</group_depend>
   <group_depend>rosidl_typesupport_cpp_packages</group_depend>
   <buildtool_export_depend>rosidl_typesupport_introspection_c</buildtool_export_depend>

--- a/rosidl_default_generators/rosidl_default_generators-extras.cmake.in
+++ b/rosidl_default_generators/rosidl_default_generators-extras.cmake.in
@@ -2,15 +2,15 @@
 # rosidl_default_generators/rosidl_default_generators-extras.cmake.in
 
 find_package(ament_cmake_core REQUIRED)
-ament_index_get_resources(rosidl_generator_packages "rosidl_generator_packages")
 ament_index_get_resources(rosidl_typesupport_c_packages "rosidl_typesupport_c")
 ament_index_get_resources(rosidl_typesupport_cpp_packages "rosidl_typesupport_cpp")
+ament_index_get_resources(rosidl_generator_packages "rosidl_generator_packages")
 set(_exported_dependencies
-  ${rosidl_generator_packages}
   "rosidl_typesupport_c"
   "rosidl_typesupport_cpp"
   ${rosidl_typesupport_c_packages}
   ${rosidl_typesupport_cpp_packages}
+  ${rosidl_generator_packages}
 )
 
 # find_package() all dependencies (if available)

--- a/rosidl_default_runtime/CMakeLists.txt
+++ b/rosidl_default_runtime/CMakeLists.txt
@@ -4,15 +4,11 @@ project(rosidl_default_runtime NONE)
 
 find_package(ament_cmake REQUIRED)
 
-ament_export_dependencies(rosidl_generator_cpp)
-ament_export_dependencies(rosidl_typesupport_c)
-ament_export_dependencies(rosidl_typesupport_cpp)
-ament_export_dependencies(rosidl_typesupport_introspection_c)
-ament_export_dependencies(rosidl_typesupport_introspection_cpp)
-
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 endif()
 
-ament_package()
+ament_package(
+  CONFIG_EXTRAS "rosidl_default_runtime-extras.cmake.in"
+)

--- a/rosidl_default_runtime/package.xml
+++ b/rosidl_default_runtime/package.xml
@@ -17,6 +17,7 @@
   <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
 
+  <group_depend>rosidl_runtime_packages</group_depend>
   <group_depend>rosidl_typesupport_c_packages</group_depend>
   <group_depend>rosidl_typesupport_cpp_packages</group_depend>
   <!-- These two dependencies cannot stay here. -->

--- a/rosidl_default_runtime/rosidl_default_runtime-extras.cmake.in
+++ b/rosidl_default_runtime/rosidl_default_runtime-extras.cmake.in
@@ -1,23 +1,14 @@
 # generated from
-# rosidl_default_generators/rosidl_default_generators-extras.cmake.in
+# rosidl_default_runtime/rosidl_default_runtime-extras.cmake.in
 
 find_package(ament_cmake_core REQUIRED)
-ament_index_get_resources(rosidl_generator_packages "rosidl_generator_packages")
-ament_index_get_resources(rosidl_typesupport_c_packages "rosidl_typesupport_c")
-ament_index_get_resources(rosidl_typesupport_cpp_packages "rosidl_typesupport_cpp")
-set(_exported_dependencies
-  ${rosidl_generator_packages}
-  "rosidl_typesupport_c"
-  "rosidl_typesupport_cpp"
-  ${rosidl_typesupport_c_packages}
-  ${rosidl_typesupport_cpp_packages}
-)
+ament_index_get_resources(rosidl_runtime_packages "rosidl_runtime_packages")
 
 # find_package() all dependencies (if available)
 # and append their DEFINITIONS INCLUDE_DIRS and LIBRARIES variables
 # to @PROJECT_NAME@_DEFINITIONS , @PROJECT_NAME@_INCLUDE_DIRS and
 # @PROJECT_NAME@_LIBRARIES.
-foreach(_dep ${_exported_dependencies})
+foreach(_dep ${rosidl_runtime_packages})
   find_package("${_dep}" QUIET)
   if(${_dep}_FOUND)
     if(${_dep}_DEFINITIONS)

--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -50,6 +50,8 @@ target_link_libraries(${PROJECT_NAME} ${Poco_LIBRARIES})
 ament_target_dependencies(${PROJECT_NAME} "rosidl_generator_c")
 ament_export_libraries(${PROJECT_NAME})
 
+ament_index_register_resource("rosidl_runtime_packages")
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -29,6 +29,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <member_of_group>rosidl_runtime_packages</member_of_group>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -47,6 +47,8 @@ target_link_libraries(${PROJECT_NAME} ${Poco_LIBRARIES})
 ament_target_dependencies(${PROJECT_NAME} "rosidl_generator_c")
 ament_export_libraries(${PROJECT_NAME})
 
+ament_index_register_resource("rosidl_runtime_packages")
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -30,6 +30,8 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
 
+  <member_of_group>rosidl_runtime_packages</member_of_group>
+
   <export>
     <build_type>ament_cmake</build_type>
   </export>


### PR DESCRIPTION
Requires ros2/rosidl#283.

The rosidl generator | runtime packages declare being a member of a group as well as register themselves at the resource index.

Additionally the default packages depend on their group and in CMake collect the available generator | runtime packages from the resource index instead of using a hard coded list (while keeping the mandatory ones explicitly listed in the manifest).

[![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=4659)](https://ci.ros2.org/job/ci_linux/4659/)