### PR TITLE
Prepare dependencies for bouncy release.

### DIFF
--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -12,6 +12,11 @@
   <build_depend>libpoco-dev</build_depend>
   <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
+  <!-- Add redundant dependencies from group rosidl_typesupport_c_packages for bloom -->
+  <build_depend>rosidl_typesupport_connext_c</build_depend>
+  <build_depend>rosidl_typesupport_introspection_c</build_depend>
+  <build_depend>rosidl_typesupport_opensplice_c</build_depend>
+  <!-- end of group rosidl_typesupport_c_packages for bloom -->
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <build_export_depend>rmw_implementation</build_export_depend>

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -26,9 +26,6 @@
   <build_export_depend>rosidl_generator_c</build_export_depend>
 
   <group_depend>rosidl_typesupport_c_packages</group_depend>
-  <build_export_depend>rosidl_typesupport_connext_c</build_export_depend>
-  <build_export_depend>rosidl_typesupport_introspection_c</build_export_depend>
-  <build_export_depend>rosidl_typesupport_opensplice_c</build_export_depend>
 
   <exec_depend>libpoco-dev</exec_depend>
   <exec_depend>poco_vendor</exec_depend>

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -12,7 +12,10 @@
   <build_depend>libpoco-dev</build_depend>
   <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
-  <!-- Add redundant dependencies from group rosidl_typesupport_c_packages for bloom -->
+  <!--
+  Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_c_packages.
+  This ensures that binary packages have support for all of these rmw impl. enabled.
+  -->
   <build_depend>rosidl_typesupport_connext_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
   <build_depend>rosidl_typesupport_opensplice_c</build_depend>

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -12,7 +12,10 @@
   <build_depend>libpoco-dev</build_depend>
   <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
-  <!-- Add redundant dependencies from group rosidl_typesupport_cpp_packages for bloom -->
+  <!--
+  Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_cpp_packages.
+  This ensures that binary packages have support for all of these rmw impl. enabled.
+  -->
   <build_depend>rosidl_typesupport_connext_cpp</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
   <build_depend>rosidl_typesupport_opensplice_cpp</build_depend>

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -27,9 +27,6 @@
   <build_export_depend>rosidl_typesupport_c</build_export_depend>
 
   <group_depend>rosidl_typesupport_cpp_packages</group_depend>
-  <build_export_depend>rosidl_typesupport_connext_cpp</build_export_depend>
-  <build_export_depend>rosidl_typesupport_introspection_cpp</build_export_depend>
-  <build_export_depend>rosidl_typesupport_opensplice_cpp</build_export_depend>
 
   <exec_depend>libpoco-dev</exec_depend>
   <exec_depend>poco_vendor</exec_depend>

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -12,6 +12,11 @@
   <build_depend>libpoco-dev</build_depend>
   <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
+  <!-- Add redundant dependencies from group rosidl_typesupport_cpp_packages for bloom -->
+  <build_depend>rosidl_typesupport_connext_cpp</build_depend>
+  <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
+  <build_depend>rosidl_typesupport_opensplice_cpp</build_depend>
+  <!-- end of group rosidl_typesupport_cpp_packages for bloom -->
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <build_export_depend>rmw_implementation</build_export_depend>


### PR DESCRIPTION
Connects to ros2/rmw_implementation#41

This change is motivated by the discussion in https://github.com/ros2/rmw_implementation/pull/41#discussion_r197289719

The build_export dependencies on the vendor typesupport packages will be moved into Suggests in the debian/control templates after bloom generates them.