### PR TITLE
Disable access to environment variables for UWP and Android

### DIFF
--- a/rosidl_typesupport_c/src/type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.cpp
@@ -45,6 +45,8 @@ std::string find_library_path(const std::string & library_name)
   filename_prefix = "lib";
   filename_extension = ".so";
 #endif
+
+#if !defined(ROSIDL_TYPESUPPORT_C_NO_ENV)
   std::string search_path = get_env_var(env_var);
   std::list<std::string> search_paths = split(search_path, separator);
 
@@ -57,9 +59,11 @@ std::string find_library_path(const std::string & library_name)
       return path;
     }
   }
+#endif
   return "";
 }
 
+#if !defined(ROSIDL_TYPESUPPORT_C_NO_ENV)
 std::string get_env_var(const char * env_var)
 {
   char * value = nullptr;
@@ -79,6 +83,7 @@ std::string get_env_var(const char * env_var)
   // printf("get_env_var(%s) = %s\n", env_var, value_str.c_str());
   return value_str;
 }
+#endif
 
 std::list<std::string> split(const std::string & value, const char delimiter)
 {

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -26,6 +26,20 @@
 #include "Poco/SharedLibrary.h"
 #endif
 
+#if defined(WIN32)
+#include <SDKDDKVer.h>
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+#include <winapifamily.h>
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#define ROSIDL_TYPESUPPORT_C_NO_ENV 1
+#endif
+#endif
+#endif
+
+#if defined(ANDROID)
+#define ROSIDL_TYPESUPPORT_C_NO_ENV 1
+#endif
+
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/type_support_map.h"
 
@@ -34,7 +48,9 @@ namespace rosidl_typesupport_c
 
 std::string find_library_path(const std::string & library_name);
 
+#if !defined(ROSIDL_TYPESUPPORT_C_NO_ENV)
 std::string get_env_var(const char * env_var);
+#endif
 
 std::list<std::string> split(const std::string & value, const char delimiter);
 

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.cpp
@@ -45,6 +45,8 @@ std::string find_library_path(const std::string & library_name)
   filename_prefix = "lib";
   filename_extension = ".so";
 #endif
+
+#if !defined(ROSIDL_TYPESUPPORT_CPP_NO_ENV)
   std::string search_path = get_env_var(env_var);
   std::list<std::string> search_paths = split(search_path, separator);
 
@@ -57,9 +59,11 @@ std::string find_library_path(const std::string & library_name)
       return path;
     }
   }
+#endif
   return "";
 }
 
+#if !defined(ROSIDL_TYPESUPPORT_CPP_NO_ENV)
 std::string get_env_var(const char * env_var)
 {
   char * value = nullptr;
@@ -79,6 +83,7 @@ std::string get_env_var(const char * env_var)
   // printf("get_env_var(%s) = %s\n", env_var, value_str.c_str());
   return value_str;
 }
+#endif
 
 std::list<std::string> split(const std::string & value, const char delimiter)
 {

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -26,6 +26,20 @@
 #include "Poco/SharedLibrary.h"
 #endif
 
+#if defined(WIN32)
+#include <SDKDDKVer.h>
+#if defined(_WIN32_WINNT) && (_WIN32_WINNT >= _WIN32_WINNT_WIN8)
+#include <winapifamily.h>
+#if WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_APP) && !WINAPI_FAMILY_PARTITION(WINAPI_PARTITION_DESKTOP)
+#define ROSIDL_TYPESUPPORT_CPP_NO_ENV 1
+#endif
+#endif
+#endif
+
+#if defined(ANDROID)
+#define ROSIDL_TYPESUPPORT_CPP_NO_ENV 1
+#endif
+
 #include "rosidl_typesupport_cpp/type_support_map.h"
 
 namespace rosidl_typesupport_cpp
@@ -33,7 +47,9 @@ namespace rosidl_typesupport_cpp
 
 std::string find_library_path(const std::string & library_name);
 
+#if !defined(ROSIDL_TYPESUPPORT_CPP_NO_ENV)
 std::string get_env_var(const char * env_var);
+#endif
 
 std::list<std::string> split(const std::string & value, const char delimiter);
 


### PR DESCRIPTION
Neither Android or UWP apps can access environment variables, this PR just disables that logic if building for either platform.

Connects to ros2/rcl#280