### PR TITLE
Generate action type supports

### DIFF
--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_action_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_action_interfaces.cmake
@@ -31,7 +31,7 @@ foreach(_idl_file ${rosidl_generate_action_interfaces_IDL_FILES})
   get_filename_component(_msg_name "${_idl_file}" NAME_WE)
   string_camel_case_to_lower_case_underscore("${_msg_name}" _header_name)
   list(APPEND _generated_files
-    "${_output_path}/${_parent_folder}/${_header_name}__type_support.cpp"
+    "${_output_path}/${_parent_folder}/${_header_name}__type_support.c"
   )
 endforeach()
 
@@ -52,9 +52,7 @@ endforeach()
 set(target_dependencies
   "${rosidl_typesupport_c_BIN}"
   ${rosidl_typesupport_c_GENERATOR_FILES}
-  "${rosidl_typesupport_c_TEMPLATE_DIR}/action__type_support.cpp.em"
-  "${rosidl_typesupport_c_TEMPLATE_DIR}/msg__type_support.cpp.em"
-  "${rosidl_typesupport_c_TEMPLATE_DIR}/srv__type_support.cpp.em"
+  "${rosidl_typesupport_c_TEMPLATE_DIR}/action__type_support.c.em"
   ${rosidl_generate_action_interfaces_IDL_FILES}
   ${_dependency_files})
 foreach(dep ${target_dependencies})
@@ -66,7 +64,7 @@ foreach(dep ${target_dependencies})
   endif()
 endforeach()
 
-set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_c__arguments.json")
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_c__generate_action_interfaces__arguments.json")
 rosidl_write_generator_arguments(
   "${generator_arguments_file}"
   PACKAGE_NAME "${PROJECT_NAME}"
@@ -90,10 +88,10 @@ add_custom_command(
 
 # generate header to switch between export and import for a specific package
 set(_visibility_control_file
-  "${_output_path}/msg/rosidl_typesupport_c__visibility_control.h")
+  "${_output_path}/action/rosidl_typesupport_c__visibility_control.h")
 string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)
 configure_file(
-  "${rosidl_typesupport_c_TEMPLATE_DIR}/rosidl_typesupport_c__visibility_control.h.in"
+  "${rosidl_typesupport_c_TEMPLATE_DIR}/rosidl_typesupport_c__action_visibility_control.h.in"
   "${_visibility_control_file}"
   @ONLY
 )

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_action_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_action_interfaces.cmake
@@ -122,6 +122,9 @@ target_include_directories(${rosidl_generate_action_interfaces_TARGET}${_target_
 )
 target_link_libraries(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_action_interfaces_TARGET}__rosidl_generator_c)
+# Add dependency to type support library for generated msg and srv for actions
+target_link_libraries(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_action_interfaces_TARGET}__rosidl_typesupport_c)
 
 # if only a single typesupport is used this package will directly reference it
 # therefore it needs to link against the selected typesupport

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_action_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_action_interfaces.cmake
@@ -96,7 +96,7 @@ configure_file(
   @ONLY
 )
 
-set(_target_suffix "__rosidl_typesupport_c")
+set(_target_suffix "__rosidl_typesupport_c__generate_action_interfaces")
 
 add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_typesupport_c_LIBRARY_TYPE} ${_generated_files})
 if(rosidl_generate_action_interfaces_LIBRARY_NAME)
@@ -170,13 +170,13 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
   if(NOT _generated_files STREQUAL "")
     find_package(ament_cmake_cppcheck REQUIRED)
     ament_cppcheck(
-      TESTNAME "cppcheck_rosidl_typesupport_c"
+      TESTNAME "cppcheck_rosidl_typesupport_c_generate_action_interfaces"
       "${_output_path}")
 
     find_package(ament_cmake_cpplint REQUIRED)
     get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
     ament_cpplint(
-      TESTNAME "cpplint_rosidl_typesupport_c"
+      TESTNAME "cpplint_rosidl_typesupport_c_generate_action_interfaces"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       ROOT "${_cpplint_root}"
@@ -184,7 +184,7 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
 
     find_package(ament_cmake_uncrustify REQUIRED)
     ament_uncrustify(
-      TESTNAME "uncrustify_rosidl_typesupport_c"
+      TESTNAME "uncrustify_rosidl_typesupport_c_generate_action_interfaces"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       "${_output_path}")

--- a/rosidl_typesupport_c/resource/action__type_support.c.em
+++ b/rosidl_typesupport_c/resource/action__type_support.c.em
@@ -1,0 +1,40 @@
+// generated from
+// rosidl_typesupport_c/resource/action__type_support_c.em
+// generated code does not contain a copyright notice
+
+#include <action_msgs/msg/goal_info.h>
+#include <action_msgs/msg/goal_status_array.h>
+#include <action_msgs/srv/cancel_goal.h>
+#include <rosidl_generator_c/action_type_support_struct.h>
+#include <test_msgs/action/fibonacci__goal.h>
+#include <test_msgs/action/fibonacci__result.h>
+#include <test_msgs/action/fibonacci__feedback.h>
+
+#include "test_msgs/action/fibonacci__type_support.h"
+
+
+static rosidl_action_type_support_t _test_msgs__action__Fibonacci__typesupport_c;
+
+const rosidl_action_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__ACTION_SYMBOL_NAME(
+  rosidl_typesupport_c, test_msgs, action, Fibonacci)()
+{
+  // Thread-safe by always writing the same values to the static struct
+  _test_msgs__action__Fibonacci__typesupport_c.goal_service_type_support =
+    ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(
+    rosidl_typesupport_c, test_msgs, action, Fibonacci_Goal)();
+  _test_msgs__action__Fibonacci__typesupport_c.result_service_type_support =
+    ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(
+    rosidl_typesupport_c, test_msgs, action, Fibonacci_Result)();
+  _test_msgs__action__Fibonacci__typesupport_c.cancel_service_type_support =
+    ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(
+    rosidl_typesupport_c, action_msgs, srv, CancelGoal)();
+  _test_msgs__action__Fibonacci__typesupport_c.feedback_message_type_support =
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+    rosidl_typesupport_c, test_msgs, action, Fibonacci_Feedback)();
+  _test_msgs__action__Fibonacci__typesupport_c.status_message_type_support =
+    ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(
+    rosidl_typesupport_c, action_msgs, msg, GoalStatusArray)();
+
+  return &_test_msgs__action__Fibonacci__typesupport_c;
+}

--- a/rosidl_typesupport_c/rosidl_typesupport_c/__init__.py
+++ b/rosidl_typesupport_c/rosidl_typesupport_c/__init__.py
@@ -19,6 +19,7 @@ from rosidl_cmake import expand_template
 from rosidl_cmake import extract_message_types
 from rosidl_cmake import get_newest_modification_time
 from rosidl_cmake import read_generator_arguments
+from rosidl_parser import parse_action_file
 from rosidl_parser import parse_message_file
 from rosidl_parser import parse_service_file
 from rosidl_parser import validate_field_types
@@ -35,6 +36,10 @@ def generate_c(generator_arguments_file, type_supports):
     mapping_srvs = {
         os.path.join(template_dir, 'srv__type_support.cpp.em'):
         '%s__type_support.cpp',
+    }
+    mapping_actions = {
+        os.path.join(template_dir, 'action__type_support.c.em'):
+        '%s__type_support.c',
     }
 
     for template_file in mapping_msgs.keys():
@@ -79,6 +84,18 @@ def generate_c(generator_arguments_file, type_supports):
 
                 data = {'spec': spec, 'subfolder': subfolder, 'type_supports': type_supports}
                 data.update(functions)
+                expand_template(
+                    template_file, data, generated_file,
+                    minimum_timestamp=latest_target_timestamp)
+
+        elif extension == '.action':
+            spec = parse_action_file(args['package_name'], ros_interface_file)
+            for template_file, generated_filename in mapping_actions.items():
+                data = {'spec': spec, 'subfolder': subfolder}
+                data.update(functions)
+                generated_file = os.path.join(
+                    args['output_dir'], subfolder, generated_filename %
+                    convert_camel_case_to_lower_case_underscore(spec.action_name))
                 expand_template(
                     template_file, data, generated_file,
                     minimum_timestamp=latest_target_timestamp)

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
@@ -52,8 +52,7 @@ endforeach()
 set(target_dependencies
   "${rosidl_typesupport_cpp_BIN}"
   ${rosidl_typesupport_cpp_GENERATOR_FILES}
-  "${rosidl_typesupport_cpp_TEMPLATE_DIR}/msg__type_support.cpp.em"
-  "${rosidl_typesupport_cpp_TEMPLATE_DIR}/srv__type_support.cpp.em"
+  "${rosidl_typesupport_cpp_TEMPLATE_DIR}/action__type_support.cpp.em"
   ${rosidl_generate_action_interfaces_IDL_FILES}
   ${_dependency_files})
 foreach(dep ${target_dependencies})
@@ -65,7 +64,7 @@ foreach(dep ${target_dependencies})
   endif()
 endforeach()
 
-set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_cpp__arguments.json")
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_cpp__generate_action_interfaces__arguments.json")
 rosidl_write_generator_arguments(
   "${generator_arguments_file}"
   PACKAGE_NAME "${PROJECT_NAME}"
@@ -107,6 +106,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 target_include_directories(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
   PUBLIC
+  ${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_cpp
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
 )
 

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
@@ -110,6 +110,10 @@ target_include_directories(${rosidl_generate_action_interfaces_TARGET}${_target_
   ${CMAKE_CURRENT_BINARY_DIR}/rosidl_generator_cpp
 )
 
+# Add dependency to type support library for generated msg and srv for actions
+target_link_libraries(${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_action_interfaces_TARGET}__rosidl_typesupport_cpp)
+
 # if only a single typesupport is used this package will directly reference it
 # therefore it needs to link against the selected typesupport
 if(NOT typesupports MATCHES ";")

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
@@ -86,7 +86,7 @@ add_custom_command(
   VERBATIM
 )
 
-set(_target_suffix "__rosidl_typesupport_cpp")
+set(_target_suffix "__generate_action_interfaces__rosidl_typesupport_cpp")
 
 add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_typesupport_cpp_LIBRARY_TYPE} ${_generated_files})
 if(rosidl_generate_action_interfaces_LIBRARY_NAME)
@@ -162,13 +162,13 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
   if(NOT _generated_files STREQUAL "")
     find_package(ament_cmake_cppcheck REQUIRED)
     ament_cppcheck(
-      TESTNAME "cppcheck_rosidl_typesupport_cpp"
+      TESTNAME "cppcheck_rosidl_typesupport_cpp_generate_action_interfaces"
       "${_output_path}")
 
     find_package(ament_cmake_cpplint REQUIRED)
     get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
     ament_cpplint(
-      TESTNAME "cpplint_rosidl_typesupport_cpp"
+      TESTNAME "cpplint_rosidl_typesupport_cpp_generate_action_interfaces"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       ROOT "${_cpplint_root}"
@@ -176,7 +176,7 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
 
     find_package(ament_cmake_uncrustify REQUIRED)
     ament_uncrustify(
-      TESTNAME "uncrustify_rosidl_typesupport_cpp"
+      TESTNAME "uncrustify_rosidl_typesupport_cpp_generate_action_interfaces"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       "${_output_path}")

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
@@ -143,9 +143,16 @@ add_dependencies(
   ${rosidl_generate_action_interfaces_TARGET}
   ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
 )
+
+# Depend on target created by rosidl_generator_cpp for including msg and srv headers it generates
 add_dependencies(
   ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_action_interfaces_TARGET}__cpp
+)
+# Depend on target created by rosidl_generator_cpp for including action headers it generates
+add_dependencies(
+  ${rosidl_generate_action_interfaces_TARGET}${_target_suffix}
+  ${rosidl_generate_action_interfaces_TARGET}__cpp__actions
 )
 
 if(NOT rosidl_generate_action_interfaces_SKIP_INSTALL)

--- a/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
@@ -25,9 +25,9 @@
 #include "rosidl_typesupport_cpp/visibility_control.h"
 
 #include "rosidl_generator_c/action_type_support_struct.h"
-#include "rosidl_generator_cpp/action_type_support_decl.hpp"
-#include "rosidl_generator_cpp/message_type_support_decl.hpp"
-#include "rosidl_generator_cpp/service_type_support_decl.hpp"
+#include "rosidl_typesupport_cpp/action_type_support.hpp"
+#include "rosidl_typesupport_cpp/message_type_support.hpp"
+#include "rosidl_typesupport_cpp/service_type_support.hpp"
 
 namespace @(spec.pkg_name)
 {
@@ -47,13 +47,13 @@ static rosidl_action_type_support_t @(spec.action_name)_action_type_support_hand
 
 }  // namespace @(spec.pkg_name)
 
-namespace rosidl_generator_cpp
+namespace rosidl_typesupport_cpp
 {
 
 template<>
 ROSIDL_TYPESUPPORT_CPP_PUBLIC
 const rosidl_action_type_support_t *
-get_action_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.action_name)>()
+get_action_type_support_handle<@(spec.pkg_name)::@(subfolder)::@(spec.action_name)>()
 {
   using ::@(spec.pkg_name)::@(subfolder)::rosidl_typesupport_cpp::@(spec.action_name)_action_type_support_handle;
   // Thread-safe by always writing the same values to the static struct
@@ -65,4 +65,4 @@ get_action_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.action_n
   return &@(spec.action_name)_action_type_support_handle;
 }
 
-}  // namespace rosidl_generator_cpp
+}  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
@@ -65,4 +65,4 @@ get_action_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.action_n
   return &@(spec.action_name)_action_type_support_handle;
 }
 
-}  // namespace rosidl_typesupport_cpp
+}  // namespace rosidl_generator_cpp

--- a/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
@@ -22,7 +22,7 @@
 #include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__goal.hpp>
 #include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__result.hpp>
 #include <@(spec.pkg_name)/@(subfolder)/@(get_header_filename_from_msg_name(spec.action_name))__struct.hpp>
-#include <@(spec.pkg_name)/action/rosidl_generator_c__visibility_control.h>
+#include "rosidl_typesupport_cpp/visibility_control.h"
 
 #include "rosidl_generator_c/action_type_support_struct.h"
 #include "rosidl_generator_cpp/action_type_support_decl.hpp"
@@ -51,17 +51,17 @@ namespace rosidl_generator_cpp
 {
 
 template<>
-ROSIDL_GENERATOR_C_PUBLIC_@(spec.pkg_name)_ACTION
+ROSIDL_TYPESUPPORT_CPP_PUBLIC
 const rosidl_action_type_support_t *
-get_action_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.pkg_name)>()
+get_action_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.action_name)>()
 {
-  using ::@(spec.pkg_name)::@(subfolder)::rosidl_generator_cpp::@(spec.action_name)_action_type_support_handle;
+  using ::@(spec.pkg_name)::@(subfolder)::rosidl_typesupport_cpp::@(spec.action_name)_action_type_support_handle;
   // Thread-safe by always writing the same values to the static struct
-  @(spec.action_name)_action_type_support_handle.goal_service_type_support = get_service_type_support_handle<::@(spec.action_name)::@(subfolder)::@(spec.action_name)::GoalRequestService>();
-  @(spec.action_name)_action_type_support_handle.result_service_type_support = get_service_type_support_handle<::@(spec.action_name)::@(subfolder)::@(spec.action_name)::GoalResultService>();
-  @(spec.action_name)_action_type_support_handle.cancel_service_type_support = get_service_type_support_handle<::@(spec.action_name)::@(subfolder)::@(spec.action_name)::CancelGoalService>();
-  @(spec.action_name)_action_type_support_handle.feedback_message_type_support = get_message_type_support_handle<::@(spec.action_name)::@(subfolder)::@(spec.action_name)::Feedback>();
-  @(spec.action_name)_action_type_support_handle.status_message_type_support = get_message_type_support_handle<::@(spec.action_name)::@(subfolder)::@(spec.action_name)::GoalStatusMessage>();
+  @(spec.action_name)_action_type_support_handle.goal_service_type_support = get_service_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.action_name)::GoalRequestService>();
+  @(spec.action_name)_action_type_support_handle.result_service_type_support = get_service_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.action_name)::GoalResultService>();
+  @(spec.action_name)_action_type_support_handle.cancel_service_type_support = get_service_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.action_name)::CancelGoalService>();
+  @(spec.action_name)_action_type_support_handle.feedback_message_type_support = get_message_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.action_name)::Feedback>();
+  @(spec.action_name)_action_type_support_handle.status_message_type_support = get_message_type_support_handle<::@(spec.pkg_name)::@(subfolder)::@(spec.action_name)::GoalStatusMessage>();
   return &@(spec.action_name)_action_type_support_handle;
 }
 

--- a/rosidl_typesupport_cpp/resource/rosidl_typesupport_cpp__action_visibility_control.h.in
+++ b/rosidl_typesupport_cpp/resource/rosidl_typesupport_cpp__action_visibility_control.h.in
@@ -1,0 +1,43 @@
+// generated from
+// rosidl_typesupport_cpp/resource/rosidl_typesupport_cpp__action_visibility_control.h.in
+// generated code does not contain a copyright notice
+
+#ifndef @PROJECT_NAME_UPPER@__ACTION__ROSIDL_TYPESUPPORT_CPP__VISIBILITY_CONTROL_H_
+#define @PROJECT_NAME_UPPER@__ACTION__ROSIDL_TYPESUPPORT_CPP__VISIBILITY_CONTROL_H_
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+// This logic was borrowed (then namespaced) from the examples on the gcc wiki:
+//     https://gcc.gnu.org/wiki/Visibility
+
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef __GNUC__
+    #define ROSIDL_TYPESUPPORT_CPP_EXPORT_@PROJECT_NAME@_ACTION __attribute__ ((dllexport))
+    #define ROSIDL_TYPESUPPORT_CPP_IMPORT_@PROJECT_NAME@_ACTION __attribute__ ((dllimport))
+  #else
+    #define ROSIDL_TYPESUPPORT_CPP_EXPORT_@PROJECT_NAME@_ACTION __declspec(dllexport)
+    #define ROSIDL_TYPESUPPORT_CPP_IMPORT_@PROJECT_NAME@_ACTION __declspec(dllimport)
+  #endif
+  #ifdef ROSIDL_TYPESUPPORT_CPP_BUILDING_DLL_@PROJECT_NAME@_ACTION
+    #define ROSIDL_TYPESUPPORT_CPP_PUBLIC_@PROJECT_NAME@_ACTION ROSIDL_TYPESUPPORT_CPP_EXPORT_@PROJECT_NAME@_ACTION
+  #else
+    #define ROSIDL_TYPESUPPORT_CPP_PUBLIC_@PROJECT_NAME@_ACTION ROSIDL_TYPESUPPORT_CPP_IMPORT_@PROJECT_NAME@_ACTION
+  #endif
+#else
+  #define ROSIDL_TYPESUPPORT_CPP_EXPORT_@PROJECT_NAME@_ACTION __attribute__ ((visibility("default")))
+  #define ROSIDL_TYPESUPPORT_CPP_IMPORT_@PROJECT_NAME@_ACTION
+  #if __GNUC__ >= 4
+    #define ROSIDL_TYPESUPPORT_CPP_PUBLIC_@PROJECT_NAME@_ACTION __attribute__ ((visibility("default")))
+  #else
+    #define ROSIDL_TYPESUPPORT_CPP_PUBLIC_@PROJECT_NAME@_ACTION
+  #endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // @PROJECT_NAME_UPPER@__ACTION__ROSIDL_TYPESUPPORT_CPP__VISIBILITY_CONTROL_H_


### PR DESCRIPTION
FYI @sservulo here's a PR targeted at your branch with some additions to make `rosidl_generate_interfaces()` try to generate the action type supports.

connects to ros2/rcl_interfaces#48