### PR TITLE
Reduces action interfaces CMake target name length to please Windows.

### DIFF
--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_action_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_action_interfaces.cmake
@@ -64,7 +64,7 @@ foreach(dep ${target_dependencies})
   endif()
 endforeach()
 
-set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_c__generate_action_interfaces__arguments.json")
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_c__generate_actions__arguments.json")
 rosidl_write_generator_arguments(
   "${generator_arguments_file}"
   PACKAGE_NAME "${PROJECT_NAME}"
@@ -86,7 +86,7 @@ add_custom_command(
   VERBATIM
 )
 
-set(_target_suffix "__rosidl_typesupport_c__generate_action_interfaces")
+set(_target_suffix "__rosidl_typesupport_c__generate_actions")
 
 add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_typesupport_c_LIBRARY_TYPE} ${_generated_files})
 if(rosidl_generate_action_interfaces_LIBRARY_NAME)
@@ -164,13 +164,13 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
   if(NOT _generated_files STREQUAL "")
     find_package(ament_cmake_cppcheck REQUIRED)
     ament_cppcheck(
-      TESTNAME "cppcheck_rosidl_typesupport_c_generate_action_interfaces"
+      TESTNAME "cppcheck_rosidl_typesupport_c_generate_actions"
       "${_output_path}")
 
     find_package(ament_cmake_cpplint REQUIRED)
     get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
     ament_cpplint(
-      TESTNAME "cpplint_rosidl_typesupport_c_generate_action_interfaces"
+      TESTNAME "cpplint_rosidl_typesupport_c_generate_actions"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       ROOT "${_cpplint_root}"
@@ -178,7 +178,7 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
 
     find_package(ament_cmake_uncrustify REQUIRED)
     ament_uncrustify(
-      TESTNAME "uncrustify_rosidl_typesupport_c_generate_action_interfaces"
+      TESTNAME "uncrustify_rosidl_typesupport_c_generate_actions"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       "${_output_path}")

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_action_interfaces.cmake
@@ -64,7 +64,7 @@ foreach(dep ${target_dependencies})
   endif()
 endforeach()
 
-set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_cpp__generate_action_interfaces__arguments.json")
+set(generator_arguments_file "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_cpp__generate_actions__arguments.json")
 rosidl_write_generator_arguments(
   "${generator_arguments_file}"
   PACKAGE_NAME "${PROJECT_NAME}"
@@ -86,7 +86,7 @@ add_custom_command(
   VERBATIM
 )
 
-set(_target_suffix "__rosidl_typesupport_cpp__generate_action_interfaces")
+set(_target_suffix "__rosidl_typesupport_cpp__generate_actions")
 
 add_library(${rosidl_generate_action_interfaces_TARGET}${_target_suffix} ${rosidl_typesupport_cpp_LIBRARY_TYPE} ${_generated_files})
 if(rosidl_generate_action_interfaces_LIBRARY_NAME)
@@ -173,13 +173,13 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
   if(NOT _generated_files STREQUAL "")
     find_package(ament_cmake_cppcheck REQUIRED)
     ament_cppcheck(
-      TESTNAME "cppcheck_rosidl_typesupport_cpp_generate_action_interfaces"
+      TESTNAME "cppcheck_rosidl_typesupport_cpp_generate_actions"
       "${_output_path}")
 
     find_package(ament_cmake_cpplint REQUIRED)
     get_filename_component(_cpplint_root "${_output_path}" DIRECTORY)
     ament_cpplint(
-      TESTNAME "cpplint_rosidl_typesupport_cpp_generate_action_interfaces"
+      TESTNAME "cpplint_rosidl_typesupport_cpp_generate_actions"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       ROOT "${_cpplint_root}"
@@ -187,7 +187,7 @@ if(BUILD_TESTING AND rosidl_generate_action_interfaces_ADD_LINTER_TESTS)
 
     find_package(ament_cmake_uncrustify REQUIRED)
     ament_uncrustify(
-      TESTNAME "uncrustify_rosidl_typesupport_cpp_generate_action_interfaces"
+      TESTNAME "uncrustify_rosidl_typesupport_cpp_generate_actions"
       # the generated code might contain longer lines for templated types
       MAX_LINE_LENGTH 999
       "${_output_path}")


### PR DESCRIPTION
Fixes ros2/build_cop#154. Had to reduce the name length for action targets a bit. I did so everywhere for consistency.