### PR TITLE
Don't validate overall actions

### DIFF
--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp/__init__.py
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp/__init__.py
@@ -93,7 +93,9 @@ def generate_cpp(generator_arguments_file, type_supports):
 
         elif extension == '.action':
             spec = parse_action_file(pkg_name, ros_interface_file)
-            validate_field_types(spec, known_msg_types)
+            # TODO(sloretz) validate field types when overall action is generated with msg and srv
+            # https://github.com/ros2/rosidl/issues/348#issuecomment-462874513
+            # validate_field_types(spec, known_msg_types)
             for template_file, generated_filename in mapping_actions.items():
                 generated_file = os.path.join(
                     args['output_dir'], subfolder, generated_filename %


### PR DESCRIPTION
Works around a limitation where the generation for the overall action doesn't know about messages in the same package. Even with this line commented out, the action fields are still validated individually when the messages and services that make up an action are generated.

Fixes ros2/rosidl#348

This PR should be backported to crystal