### PR TITLE
[Crystal patch 3 backport] Don't validate overall actions (#44)

### DIFF
--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp/__init__.py
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp/__init__.py
@@ -93,7 +93,9 @@ def generate_cpp(generator_arguments_file, type_supports):
 
         elif extension == '.action':
             spec = parse_action_file(pkg_name, ros_interface_file)
-            validate_field_types(spec, known_msg_types)
+            # TODO(sloretz) validate field types when overall action is generated with msg and srv
+            # https://github.com/ros2/rosidl/issues/348#issuecomment-462874513
+            # validate_field_types(spec, known_msg_types)
             for template_file, generated_filename in mapping_actions.items():
                 generated_file = os.path.join(
                     args['output_dir'], subfolder, generated_filename %


### PR DESCRIPTION
This is a backport of #44. Note: this branch is just a fast-forward to 183782ee9945009473fed1d67b8a5a3e602db722 since there are no other changes since crystal release. ~~As such it can be merged instead of squash/merged.~~ [*Edit: looks like the right button is rebase and merge since merge forces a merge commit*](https://help.github.com/en/articles/about-pull-request-merges)

ros2/ros2#656