### PR TITLE
Remove OpenSplice dependencies

### DIFF
--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -19,7 +19,6 @@
   -->
   <build_depend>rosidl_typesupport_connext_c</build_depend>
   <build_depend>rosidl_typesupport_introspection_c</build_depend>
-  <build_depend>rosidl_typesupport_opensplice_c</build_depend>
   <!-- end of group rosidl_typesupport_c_packages for bloom -->
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -19,7 +19,6 @@
   -->
   <build_depend>rosidl_typesupport_connext_cpp</build_depend>
   <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
-  <build_depend>rosidl_typesupport_opensplice_cpp</build_depend>
   <!-- end of group rosidl_typesupport_cpp_packages for bloom -->
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>


### PR DESCRIPTION
Support for OpenSplice has been discontinued from ROS Foxy onwards.
Find a discussion here: https://discourse.ros.org/t/opensplice-move-to-eclipse-cyclone-dds-in-ros-2/12370