### PR TITLE
[eloquent backport] Make Poco optional again (#54)

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -46,7 +46,11 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC
   include
 )
-ament_target_dependencies(${PROJECT_NAME} "Poco" "rosidl_generator_c")
+
+if(Poco_FOUND)
+  ament_target_dependencies(${PROJECT_NAME} "Poco")
+endif()
+ament_target_dependencies(${PROJECT_NAME} "rosidl_generator_c")
 ament_export_libraries(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -43,8 +43,11 @@ target_include_directories(${PROJECT_NAME}
   PUBLIC
   include
 )
-target_link_libraries(${PROJECT_NAME} ${Poco_LIBRARIES})
-ament_target_dependencies(${PROJECT_NAME} "Poco" "rosidl_generator_c")
+
+if(Poco_FOUND)
+  ament_target_dependencies(${PROJECT_NAME} "Poco")
+endif()
+ament_target_dependencies(${PROJECT_NAME} "rosidl_generator_c")
 ament_export_libraries(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")


### PR DESCRIPTION
Poco library is only needed if multiple DDS implementations are to be
supported. For 'static' builds with a single DDS in the sources, Poco
can be omitted.

Closes #53

Signed-off-by: Sean Kelly <sean@seankelly.dev>