### PR TITLE
Removed poco dependency

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -16,13 +16,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
-# provides FindPoco.cmake and Poco on platforms without it
-find_package(poco_vendor)
-find_package(Poco COMPONENTS Foundation)
+find_package(rcutils REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
-
-link_directories(${Poco_LIBRARY_DIR})
 
 ament_export_dependencies(rosidl_typesupport_interface)
 
@@ -35,23 +31,18 @@ add_library(${PROJECT_NAME}
   src/message_type_support_dispatch.cpp
   src/service_type_support_dispatch.cpp
   src/type_support_dispatch.cpp)
-if(Poco_FOUND)
-  target_compile_definitions(${PROJECT_NAME}
-    PRIVATE "ROSIDL_TYPESUPPORT_C_USE_POCO")
-endif()
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_C_BUILDING_DLL")
 endif()
+target_link_libraries(${PROJECT_NAME})
+
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   include
 )
 
-if(Poco_FOUND)
-  ament_target_dependencies(${PROJECT_NAME} "Poco")
-endif()
-ament_target_dependencies(${PROJECT_NAME} "rcpputils" "rosidl_generator_c")
+ament_target_dependencies(${PROJECT_NAME} "rcpputils" "rcutils" "rosidl_generator_c")
 ament_export_libraries(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")

--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -16,7 +16,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
-find_package(rcutils REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
 
@@ -41,7 +40,7 @@ target_include_directories(${PROJECT_NAME}
   include
 )
 
-ament_target_dependencies(${PROJECT_NAME} "rcpputils" "rcutils" "rosidl_generator_c")
+ament_target_dependencies(${PROJECT_NAME} "rcpputils" "rosidl_generator_c")
 ament_export_libraries(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")

--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -35,7 +35,6 @@ if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_C_BUILDING_DLL")
 endif()
-target_link_libraries(${PROJECT_NAME})
 
 target_include_directories(${PROJECT_NAME}
   PUBLIC

--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -34,7 +34,6 @@ if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_C_BUILDING_DLL")
 endif()
-
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   include

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -123,10 +123,6 @@ else()
     message(FATAL_ERROR "Multiple typesupports [${typesupports}] but static "
       "linking was requested")
   endif()
-  if(NOT rosidl_typesupport_c_SUPPORTS_POCO)
-    message(FATAL_ERROR "Multiple typesupports [${typesupports}] but Poco was "
-      "not available when rosidl_typesupport_c was built")
-  endif()
 endif()
 
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -9,7 +9,6 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <depend>rcutils</depend>
   <depend>rcpputils</depend>
   <build_depend>rosidl_generator_c</build_depend>
   <!--

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -9,9 +9,8 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>rcutils</depend>
   <depend>rcpputils</depend>
-  <build_depend>libpoco-dev</build_depend>
-  <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
   <!--
   Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_c_packages.
@@ -25,8 +24,6 @@
   <build_export_depend>rmw_implementation</build_export_depend>
   <build_export_depend>rosidl_generator_c</build_export_depend>
 
-  <exec_depend>libpoco-dev</exec_depend>
-  <exec_depend>poco_vendor</exec_depend>
   <exec_depend>rosidl_typesupport_interface</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
+++ b/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
@@ -13,8 +13,6 @@ ament_register_extension(
   "rosidl_typesupport_c"
   "rosidl_typesupport_c_generate_interfaces.cmake")
 
-set(rosidl_typesupport_c_SUPPORTS_POCO @Poco_FOUND@)
-
 set(rosidl_typesupport_c_BIN
   "${rosidl_typesupport_c_DIR}/../../../lib/rosidl_typesupport_c/rosidl_typesupport_c")
 normalize_path(rosidl_typesupport_c_BIN

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -67,11 +67,11 @@ get_typesupport_handle_function(
           lib = new rcpputils::SharedLibrary(library_path.c_str());
         } catch (const std::runtime_error & e) {
           throw std::runtime_error(
-                  "Could not load library " + library_path + " :" +
+                  "Could not load library " + library_path + ": " +
                   std::string(e.what()));
         } catch (const std::bad_alloc & e) {
           throw std::runtime_error(
-                  "Could not load library " + library_path + " :" +
+                  "Could not load library " + library_path + ": " +
                   std::string(e.what()));
         }
         map->data[i] = lib;

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -66,6 +66,8 @@ get_typesupport_handle_function(
           lib = new rcpputils::SharedLibrary(library_path.c_str());
         } catch (const std::runtime_error & e) {
           throw std::runtime_error("Could not load library " + std::string(e.what()));
+        } catch (const std::bad_alloc & e) {
+          throw std::bad_alloc();
         }
         map->data[i] = lib;
       }

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -66,9 +66,13 @@ get_typesupport_handle_function(
         try {
           lib = new rcpputils::SharedLibrary(library_path.c_str());
         } catch (const std::runtime_error & e) {
-          throw std::runtime_error("Could not load library " + std::string(e.what()));
+          throw std::runtime_error(
+                  "Could not load library " + library_path + " :" +
+                  std::string(e.what()));
         } catch (const std::bad_alloc & e) {
-          throw std::bad_alloc();
+          throw std::runtime_error(
+                  "Could not load library " + library_path + " :" +
+                  std::string(e.what()));
         }
         map->data[i] = lib;
       }

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
+#include <memory>
 #include <stdexcept>
 
 #include <list>
@@ -50,7 +51,6 @@ get_typesupport_handle_function(
         continue;
       }
       rcutils_shared_library_t * lib = nullptr;
-      rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
       if (!map->data[i]) {
         char library_name[1024];
@@ -62,17 +62,12 @@ get_typesupport_handle_function(
           throw std::runtime_error("Failed to find library '" + std::string(library_name) + "'");
         }
 
-        lib = static_cast<rcutils_shared_library_t *>(allocator.allocate(
-            sizeof(rcutils_shared_library_t), allocator.state));
-        if (!lib) {
-          throw std::bad_alloc();
-        }
-
+        lib = new rcutils_shared_library_t;
         *lib = rcutils_get_zero_initialized_shared_library();
 
         rcutils_ret_t ret = rcutils_load_shared_library(lib, library_path.c_str());
         if (ret != RCUTILS_RET_OK) {
-          allocator.deallocate(lib, allocator.state);
+          delete lib;
           if (ret == RCUTILS_RET_INVALID_ARGUMENT) {
             throw std::runtime_error("Invaled arguments in rcutils_load_shared_library");
           } else if (ret == RCUTILS_RET_BAD_ALLOC) {
@@ -86,7 +81,7 @@ get_typesupport_handle_function(
       auto clib = static_cast<rcutils_shared_library_t *>(map->data[i]);
       void * sym = rcutils_get_symbol(clib, map->symbol_name[i]);
       if (!sym) {
-        allocator.deallocate(lib, allocator.state);
+        delete lib;
         throw std::runtime_error(
                 "Failed to find symbol '" + std::string(
                   map->symbol_name[i]) + "' in library");

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -18,9 +18,9 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
+
 #include <memory>
 #include <stdexcept>
-
 #include <list>
 #include <string>
 
@@ -59,7 +59,8 @@ get_typesupport_handle_function(
           map->package_name, identifier);
         std::string library_path = rcpputils::find_library_path(library_name);
         if (library_path.empty()) {
-          throw std::runtime_error("Failed to find library '" + std::string(library_name) + "'");
+          fprintf(stderr, "Failed to find library '%s'\n", library_name);
+          return nullptr;
         }
 
         try {
@@ -74,9 +75,8 @@ get_typesupport_handle_function(
       auto clib = static_cast<const rcpputils::SharedLibrary *>(map->data[i]);
       lib = const_cast<rcpputils::SharedLibrary *>(clib);
       if (!lib->has_symbol(map->symbol_name[i])) {
-        throw std::runtime_error(
-                "Failed to find symbol '" + std::string(
-                  map->symbol_name[i]) + "' in library");
+        fprintf(stderr, "Failed to find symbol '%s' in library\n", map->symbol_name[i]);
+        return nullptr;
       }
       void * sym = lib->get_symbol(map->symbol_name[i]);
 

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -24,8 +24,8 @@
 #include <list>
 #include <string>
 
-#include "rcutils/shared_library.h"
 #include "rcpputils/find_library.hpp"
+#include "rcpputils/shared_library.hpp"
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/type_support_map.h"
 
@@ -50,7 +50,7 @@ get_typesupport_handle_function(
       if (strcmp(map->typesupport_identifier[i], identifier) != 0) {
         continue;
       }
-      rcutils_shared_library_t * lib = nullptr;
+      rcpputils::SharedLibrary * lib = nullptr;
 
       if (!map->data[i]) {
         char library_name[1024];
@@ -62,30 +62,21 @@ get_typesupport_handle_function(
           throw std::runtime_error("Failed to find library '" + std::string(library_name) + "'");
         }
 
-        lib = new rcutils_shared_library_t;
-        *lib = rcutils_get_zero_initialized_shared_library();
-
-        rcutils_ret_t ret = rcutils_load_shared_library(lib, library_path.c_str());
-        if (ret != RCUTILS_RET_OK) {
-          delete lib;
-          if (ret == RCUTILS_RET_INVALID_ARGUMENT) {
-            throw std::runtime_error("Invaled arguments in rcutils_load_shared_library");
-          } else if (ret == RCUTILS_RET_BAD_ALLOC) {
-            throw std::bad_alloc();
-          } else {
-            throw std::runtime_error("Cannot open library " + library_path);
-          }
+        try {
+          lib = new rcpputils::SharedLibrary(library_path.c_str());
+        } catch (const std::runtime_error & e) {
+          throw std::runtime_error("Could not load library " + std::string(e.what()));
         }
         map->data[i] = lib;
       }
-      auto clib = static_cast<rcutils_shared_library_t *>(map->data[i]);
-      void * sym = rcutils_get_symbol(clib, map->symbol_name[i]);
-      if (!sym) {
-        delete lib;
+      auto clib = static_cast<const rcpputils::SharedLibrary *>(map->data[i]);
+      lib = const_cast<rcpputils::SharedLibrary *>(clib);
+      if (!lib->has_symbol(map->symbol_name[i])) {
         throw std::runtime_error(
                 "Failed to find symbol '" + std::string(
                   map->symbol_name[i]) + "' in library");
       }
+      void * sym = lib->get_symbol(map->symbol_name[i]);
 
       typedef const TypeSupport * (* funcSignature)(void);
       funcSignature func = reinterpret_cast<funcSignature>(sym);

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -32,7 +32,6 @@ if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_CPP_BUILDING_DLL")
 endif()
-target_link_libraries(${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   include

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -12,13 +12,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
-# provides FindPoco.cmake and Poco on platforms without it
-find_package(poco_vendor)
-find_package(Poco COMPONENTS Foundation)
+find_package(rcutils REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
-
-link_directories(${Poco_LIBRARY_DIR})
 
 ament_export_dependencies(rosidl_typesupport_interface)
 ament_export_dependencies(rosidl_typesupport_c)
@@ -32,23 +28,17 @@ add_library(${PROJECT_NAME}
   src/message_type_support_dispatch.cpp
   src/service_type_support_dispatch.cpp
   src/type_support_dispatch.cpp)
-if(Poco_FOUND)
-  target_compile_definitions(${PROJECT_NAME}
-    PRIVATE "ROSIDL_TYPESUPPORT_CPP_USE_POCO")
-endif()
 if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_CPP_BUILDING_DLL")
 endif()
+target_link_libraries(${PROJECT_NAME})
 target_include_directories(${PROJECT_NAME}
   PUBLIC
   include
 )
 
-if(Poco_FOUND)
-  ament_target_dependencies(${PROJECT_NAME} "Poco")
-endif()
-ament_target_dependencies(${PROJECT_NAME} "rcpputils" "rosidl_generator_c")
+ament_target_dependencies(${PROJECT_NAME} "rcpputils" "rcutils" "rosidl_generator_c")
 ament_export_libraries(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -12,7 +12,6 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
-find_package(rcutils REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_generator_c REQUIRED)
 
@@ -37,7 +36,7 @@ target_include_directories(${PROJECT_NAME}
   include
 )
 
-ament_target_dependencies(${PROJECT_NAME} "rcpputils" "rcutils" "rosidl_generator_c")
+ament_target_dependencies(${PROJECT_NAME} "rcpputils" "rosidl_generator_c")
 ament_export_libraries(${PROJECT_NAME})
 
 ament_index_register_resource("rosidl_runtime_packages")

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -109,10 +109,6 @@ else()
     message(FATAL_ERROR "Multiple typesupports [${typesupports}] but static "
       "linking was requested")
   endif()
-  if(NOT rosidl_typesupport_cpp_SUPPORTS_POCO)
-    message(FATAL_ERROR "Multiple typesupports [${typesupports}] but Poco was "
-      "not available when rosidl_typesupport_cpp was built")
-  endif()
 endif()
 
 ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -9,9 +9,8 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <depend>rcutils</depend>
   <depend>rcpputils</depend>
-  <build_depend>libpoco-dev</build_depend>
-  <build_depend>poco_vendor</build_depend>
   <build_depend>rosidl_generator_c</build_depend>
   <!--
   Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_cpp_packages.
@@ -26,8 +25,6 @@
   <build_export_depend>rosidl_generator_c</build_export_depend>
   <build_export_depend>rosidl_typesupport_c</build_export_depend>
 
-  <exec_depend>libpoco-dev</exec_depend>
-  <exec_depend>poco_vendor</exec_depend>
   <exec_depend>rosidl_typesupport_interface</exec_depend>
 
   <test_depend>ament_lint_auto</test_depend>

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -9,7 +9,6 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
-  <depend>rcutils</depend>
   <depend>rcpputils</depend>
   <build_depend>rosidl_generator_c</build_depend>
   <!--

--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
@@ -11,8 +11,6 @@ ament_register_extension(
   "rosidl_typesupport_cpp"
   "rosidl_typesupport_cpp_generate_interfaces.cmake")
 
-set(rosidl_typesupport_cpp_SUPPORTS_POCO @Poco_FOUND@)
-
 set(rosidl_typesupport_cpp_BIN
   "${rosidl_typesupport_cpp_DIR}/../../../lib/rosidl_typesupport_cpp/rosidl_typesupport_cpp")
 normalize_path(rosidl_typesupport_cpp_BIN

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -64,9 +64,13 @@ get_typesupport_handle_function(
         try {
           lib = new rcpputils::SharedLibrary(library_path.c_str());
         } catch (const std::runtime_error & e) {
-          throw std::runtime_error("Could not load library " + std::string(e.what()));
+          throw std::runtime_error(
+                  "Could not load library " + library_path + " :" +
+                  std::string(e.what()));
         } catch (const std::bad_alloc & e) {
-          throw std::bad_alloc();
+          throw std::runtime_error(
+                  "Could not load library " + library_path + " :" +
+                  std::string(e.what()));
         }
         map->data[i] = lib;
       }

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -21,10 +21,7 @@
 
 #include <string>
 
-#ifdef ROSIDL_TYPESUPPORT_CPP_USE_POCO
-#include "Poco/SharedLibrary.h"
-#endif
-
+#include "rcutils/shared_library.h"
 #include "rcpputils/find_library.hpp"
 #include "rosidl_typesupport_cpp/type_support_map.h"
 
@@ -42,7 +39,6 @@ get_typesupport_handle_function(
     return handle;
   }
 
-#ifdef ROSIDL_TYPESUPPORT_CPP_USE_POCO
   if (handle->typesupport_identifier == rosidl_typesupport_cpp::typesupport_identifier) {
     const type_support_map_t * map = \
       static_cast<const type_support_map_t *>(handle->data);
@@ -50,7 +46,17 @@ get_typesupport_handle_function(
       if (strcmp(map->typesupport_identifier[i], identifier) != 0) {
         continue;
       }
-      Poco::SharedLibrary * lib = nullptr;
+      rcutils_shared_library_t * lib = nullptr;
+      rcutils_allocator_t allocator = rcutils_get_default_allocator();
+      lib = static_cast<rcutils_shared_library_t *>(allocator.allocate(
+              sizeof(rcutils_shared_library_t), allocator.state));
+      if (!lib) {
+        fprintf(stderr, "failed to allocate memory");
+        return nullptr;
+      }
+
+      *lib = rcutils_get_zero_initialized_shared_library();
+
       if (!map->data[i]) {
         char library_name[1024];
         snprintf(
@@ -61,16 +67,19 @@ get_typesupport_handle_function(
           fprintf(stderr, "Failed to find library '%s'\n", library_name);
           return nullptr;
         }
-        lib = new Poco::SharedLibrary(library_path);
+        rcutils_ret_t ret = rcutils_load_shared_library(lib, library_path.c_str());
+        if (ret != RCUTILS_RET_OK) {
+          fprintf(stderr, "Cannot open library %s", library_path.c_str());
+          return nullptr;
+        }
         map->data[i] = lib;
       }
-      auto clib = static_cast<const Poco::SharedLibrary *>(map->data[i]);
-      lib = const_cast<Poco::SharedLibrary *>(clib);
-      if (!lib->hasSymbol(map->symbol_name[i])) {
+      auto clib = static_cast<rcutils_shared_library_t *>(map->data[i]);
+      void * sym = rcutils_get_symbol(clib, map->symbol_name[i]);
+      if (!sym) {
         fprintf(stderr, "Failed to find symbol '%s' in library\n", map->symbol_name[i]);
         return nullptr;
       }
-      void * sym = lib->getSymbol(map->symbol_name[i]);
 
       typedef const TypeSupport * (* funcSignature)(void);
       funcSignature func = reinterpret_cast<funcSignature>(sym);
@@ -78,8 +87,6 @@ get_typesupport_handle_function(
       return ts;
     }
   }
-#endif
-
   return nullptr;
 }
 

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -65,11 +65,11 @@ get_typesupport_handle_function(
           lib = new rcpputils::SharedLibrary(library_path.c_str());
         } catch (const std::runtime_error & e) {
           throw std::runtime_error(
-                  "Could not load library " + library_path + " :" +
+                  "Could not load library " + library_path + ": " +
                   std::string(e.what()));
         } catch (const std::bad_alloc & e) {
           throw std::runtime_error(
-                  "Could not load library " + library_path + " :" +
+                  "Could not load library " + library_path + ": " +
                   std::string(e.what()));
         }
         map->data[i] = lib;

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -64,6 +64,8 @@ get_typesupport_handle_function(
           lib = new rcpputils::SharedLibrary(library_path.c_str());
         } catch (const std::runtime_error & e) {
           throw std::runtime_error("Could not load library " + std::string(e.what()));
+        } catch (const std::bad_alloc & e) {
+          throw std::bad_alloc();
         }
         map->data[i] = lib;
       }

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -57,7 +57,8 @@ get_typesupport_handle_function(
           map->package_name, identifier);
         std::string library_path = rcpputils::find_library_path(library_name);
         if (library_path.empty()) {
-          throw std::runtime_error("Failed to find library '" + std::string(library_name) + "'");
+          fprintf(stderr, "Failed to find library '%s'\n", library_name);
+          return nullptr;
         }
 
         try {
@@ -72,9 +73,8 @@ get_typesupport_handle_function(
       auto clib = static_cast<const rcpputils::SharedLibrary *>(map->data[i]);
       lib = const_cast<rcpputils::SharedLibrary *>(clib);
       if (!lib->has_symbol(map->symbol_name[i])) {
-        throw std::runtime_error(
-                "Failed to find symbol '" + std::string(
-                  map->symbol_name[i]) + "' in library");
+        fprintf(stderr, "Failed to find symbol '%s' in library\n", map->symbol_name[i]);
+        return nullptr;
       }
       void * sym = lib->get_symbol(map->symbol_name[i]);
 

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
+#include <memory>
 #include <stdexcept>
 
 #include <string>
@@ -48,7 +49,6 @@ get_typesupport_handle_function(
         continue;
       }
       rcutils_shared_library_t * lib = nullptr;
-      rcutils_allocator_t allocator = rcutils_get_default_allocator();
 
       if (!map->data[i]) {
         char library_name[1024];
@@ -60,17 +60,12 @@ get_typesupport_handle_function(
           throw std::runtime_error("Failed to find library '" + std::string(library_name) + "'");
         }
 
-        lib = static_cast<rcutils_shared_library_t *>(allocator.allocate(
-            sizeof(rcutils_shared_library_t), allocator.state));
-        if (!lib) {
-          throw std::bad_alloc();
-        }
-
+        lib = new rcutils_shared_library_t;
         *lib = rcutils_get_zero_initialized_shared_library();
 
         rcutils_ret_t ret = rcutils_load_shared_library(lib, library_path.c_str());
         if (ret != RCUTILS_RET_OK) {
-          allocator.deallocate(lib, allocator.state);
+          delete lib;
           if (ret == RCUTILS_RET_INVALID_ARGUMENT) {
             throw std::runtime_error("Invaled arguments in rcutils_load_shared_library");
           } else if (ret == RCUTILS_RET_BAD_ALLOC) {
@@ -84,7 +79,7 @@ get_typesupport_handle_function(
       auto clib = static_cast<rcutils_shared_library_t *>(map->data[i]);
       void * sym = rcutils_get_symbol(clib, map->symbol_name[i]);
       if (!sym) {
-        allocator.deallocate(lib, allocator.state);
+        delete lib;
         throw std::runtime_error(
                 "Failed to find symbol '" + std::string(
                   map->symbol_name[i]) + "' in library");

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
+#include <stdexcept>
 
 #include <string>
 
@@ -48,14 +49,6 @@ get_typesupport_handle_function(
       }
       rcutils_shared_library_t * lib = nullptr;
       rcutils_allocator_t allocator = rcutils_get_default_allocator();
-      lib = static_cast<rcutils_shared_library_t *>(allocator.allocate(
-              sizeof(rcutils_shared_library_t), allocator.state));
-      if (!lib) {
-        fprintf(stderr, "failed to allocate memory");
-        return nullptr;
-      }
-
-      *lib = rcutils_get_zero_initialized_shared_library();
 
       if (!map->data[i]) {
         char library_name[1024];
@@ -64,21 +57,37 @@ get_typesupport_handle_function(
           map->package_name, identifier);
         std::string library_path = rcpputils::find_library_path(library_name);
         if (library_path.empty()) {
-          fprintf(stderr, "Failed to find library '%s'\n", library_name);
-          return nullptr;
+          throw std::runtime_error("Failed to find library '" + std::string(library_name) + "'");
         }
+
+        lib = static_cast<rcutils_shared_library_t *>(allocator.allocate(
+            sizeof(rcutils_shared_library_t), allocator.state));
+        if (!lib) {
+          throw std::bad_alloc();
+        }
+
+        *lib = rcutils_get_zero_initialized_shared_library();
+
         rcutils_ret_t ret = rcutils_load_shared_library(lib, library_path.c_str());
         if (ret != RCUTILS_RET_OK) {
-          fprintf(stderr, "Cannot open library %s", library_path.c_str());
-          return nullptr;
+          allocator.deallocate(lib, allocator.state);
+          if (ret == RCUTILS_RET_INVALID_ARGUMENT) {
+            throw std::runtime_error("Invaled arguments in rcutils_load_shared_library");
+          } else if (ret == RCUTILS_RET_BAD_ALLOC) {
+            throw std::bad_alloc();
+          } else {
+            throw std::runtime_error("Cannot open library " + library_path);
+          }
         }
         map->data[i] = lib;
       }
       auto clib = static_cast<rcutils_shared_library_t *>(map->data[i]);
       void * sym = rcutils_get_symbol(clib, map->symbol_name[i]);
       if (!sym) {
-        fprintf(stderr, "Failed to find symbol '%s' in library\n", map->symbol_name[i]);
-        return nullptr;
+        allocator.deallocate(lib, allocator.state);
+        throw std::runtime_error(
+                "Failed to find symbol '" + std::string(
+                  map->symbol_name[i]) + "' in library");
       }
 
       typedef const TypeSupport * (* funcSignature)(void);


### PR DESCRIPTION
As part of the effort to remove Poco dependency described in this issue https://github.com/ros2/ros2/issues/867 this PR makes use of the recent changes in rcutils https://github.com/ros2/rcutils/pull/215 to load, unload and get symbols from shared libraries instead of using Poco.

Signed-off-by: ahcorde <ahcorde@gmail.com>