### PR TITLE
rename rosidl_generator_c namespace to rosidl_runtime_c

### DIFF
--- a/rosidl_typesupport_c/include/rosidl_typesupport_c/message_type_support_dispatch.h
+++ b/rosidl_typesupport_c/include/rosidl_typesupport_c/message_type_support_dispatch.h
@@ -15,7 +15,7 @@
 #ifndef ROSIDL_TYPESUPPORT_C__MESSAGE_TYPE_SUPPORT_DISPATCH_H_
 #define ROSIDL_TYPESUPPORT_C__MESSAGE_TYPE_SUPPORT_DISPATCH_H_
 
-#include "rosidl_generator_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/message_type_support_struct.h"
 
 #include "rosidl_typesupport_c/visibility_control.h"
 

--- a/rosidl_typesupport_c/include/rosidl_typesupport_c/service_type_support_dispatch.h
+++ b/rosidl_typesupport_c/include/rosidl_typesupport_c/service_type_support_dispatch.h
@@ -15,7 +15,7 @@
 #ifndef ROSIDL_TYPESUPPORT_C__SERVICE_TYPE_SUPPORT_DISPATCH_H_
 #define ROSIDL_TYPESUPPORT_C__SERVICE_TYPE_SUPPORT_DISPATCH_H_
 
-#include "rosidl_generator_c/service_type_support_struct.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
 
 #include "rosidl_typesupport_c/visibility_control.h"
 

--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -7,7 +7,7 @@ include_base = '/'.join(include_parts)
 
 header_files = [
     'cstddef',
-    'rosidl_generator_c/message_type_support_struct.h',
+    'rosidl_runtime_c/message_type_support_struct.h',
     package_name + '/msg/rosidl_typesupport_c__visibility_control.h',
     include_base + '__struct.h',
 ]

--- a/rosidl_typesupport_c/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/srv__type_support.cpp.em
@@ -23,7 +23,7 @@ include_base = '/'.join(include_parts)
 
 header_files = [
     'cstddef',
-    'rosidl_generator_c/service_type_support_struct.h',
+    'rosidl_runtime_c/service_type_support_struct.h',
     package_name + '/msg/rosidl_typesupport_c__visibility_control.h',
 ]
 if len(type_supports) != 1:

--- a/rosidl_typesupport_cpp/include/rosidl_typesupport_cpp/message_type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/include/rosidl_typesupport_cpp/message_type_support_dispatch.hpp
@@ -15,8 +15,8 @@
 #ifndef ROSIDL_TYPESUPPORT_CPP__MESSAGE_TYPE_SUPPORT_DISPATCH_HPP_
 #define ROSIDL_TYPESUPPORT_CPP__MESSAGE_TYPE_SUPPORT_DISPATCH_HPP_
 
-#include "rosidl_generator_c/message_type_support_struct.h"
-#include "rosidl_generator_c/visibility_control.h"
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/visibility_control.h"
 
 #include "rosidl_typesupport_cpp/visibility_control.h"
 

--- a/rosidl_typesupport_cpp/include/rosidl_typesupport_cpp/service_type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/include/rosidl_typesupport_cpp/service_type_support_dispatch.hpp
@@ -15,8 +15,8 @@
 #ifndef ROSIDL_TYPESUPPORT_CPP__SERVICE_TYPE_SUPPORT_DISPATCH_HPP_
 #define ROSIDL_TYPESUPPORT_CPP__SERVICE_TYPE_SUPPORT_DISPATCH_HPP_
 
-#include "rosidl_generator_c/service_type_support_struct.h"
-#include "rosidl_generator_c/visibility_control.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
+#include "rosidl_runtime_c/visibility_control.h"
 
 #include "rosidl_typesupport_cpp/visibility_control.h"
 

--- a/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
@@ -10,7 +10,7 @@ header_files = (
     'action_msgs/srv/cancel_goal.hpp',
     include_base + '__struct.hpp',
     'rosidl_typesupport_cpp/visibility_control.h',
-    'rosidl_generator_c/action_type_support_struct.h',
+    'rosidl_runtime_c/action_type_support_struct.h',
     'rosidl_typesupport_cpp/action_type_support.hpp',
     'rosidl_typesupport_cpp/message_type_support.hpp',
     'rosidl_typesupport_cpp/service_type_support.hpp',

--- a/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
@@ -7,7 +7,7 @@ include_base = '/'.join(include_parts)
 
 header_files = [
     'cstddef',
-    'rosidl_generator_c/message_type_support_struct.h',
+    'rosidl_runtime_c/message_type_support_struct.h',
     include_base + '__struct.hpp',
 ]
 if len(type_supports) != 1:

--- a/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
@@ -23,7 +23,7 @@ include_base = '/'.join(include_parts)
 
 header_files = [
     'cstddef',
-    'rosidl_generator_c/service_type_support_struct.h',
+    'rosidl_runtime_c/service_type_support_struct.h',
     include_base + '__struct.hpp',
 ]
 if len(type_supports) != 1:


### PR DESCRIPTION
Related to ros2/rosidl#458.