### PR TITLE
fix single typesupport build exposing build directory in include dirs

### DIFF
--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -115,7 +115,7 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 if(NOT typesupports MATCHES ";")
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/${typesupports}")
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${typesupports}>")
   target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}__${typesupports})
 else()

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -102,7 +102,7 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 if(NOT typesupports MATCHES ";")
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PUBLIC
-    "${CMAKE_CURRENT_BINARY_DIR}/${typesupports}")
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${typesupports}>")
   target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}__${typesupports})
 else()


### PR DESCRIPTION
Fixes https://github.com/osrf/buildfarmer/issues/29#issuecomment-619070630. Related to ros2/ros2#904.

Linux CI builds up to `builtin_interfaces` with only CycloneDDS:

* Before: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10487)](https://ci.ros2.org/job/ci_linux/10487/)
* After: [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10493)](https://ci.ros2.org/job/ci_linux/10493/)