### PR TITLE
Completing feature documentation

### DIFF
--- a/rosidl_typesupport_c/Doxyfile
+++ b/rosidl_typesupport_c/Doxyfile
@@ -5,7 +5,7 @@ PROJECT_NUMBER         = master
 PROJECT_BRIEF          = "ROSIDL C Typesupport"
 
 # Use these lines to include the generated logging.hpp (update install path if needed)
-INPUT                  = README.md ./include
+INPUT                  = README.md ./include ./docs
 USE_MDFILE_AS_MAINPAGE = README.md
 
 RECURSIVE              = YES
@@ -23,7 +23,6 @@ PREDEFINED             = ROSIDL_TYPESUPPORT_C_PUBLIC=
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
-# TODO(brawner) uncomment when rosidl_runtime_c docs are created
-# TAGFILES += "../../../../doxygen_tag_files/rosidl_runtime_c.tag=http://docs.ros2.org/latest/api/rosidl_runtime_c/"
+TAGFILES += "../../../../doxygen_tag_files/rosidl_runtime_c.tag=http://docs.ros2.org/latest/api/rosidl_runtime_c/"
 # Uncomment to generate tag files for cross-project linking.
-#GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclcpp.tag"
+#GENERATE_TAGFILE = "../../../../doxygen_tag_files/rosidl_typesupport_c.tag"

--- a/rosidl_typesupport_c/Doxyfile
+++ b/rosidl_typesupport_c/Doxyfile
@@ -5,7 +5,7 @@ PROJECT_NUMBER         = master
 PROJECT_BRIEF          = "ROSIDL C Typesupport"
 
 # Use these lines to include the generated logging.hpp (update install path if needed)
-INPUT                  = README.md ./include ./docs
+INPUT                  = README.md ./include ./docs ./QUALITY_DECLARATION.md
 USE_MDFILE_AS_MAINPAGE = README.md
 
 RECURSIVE              = YES

--- a/rosidl_typesupport_c/QUALITY_DECLARATION.md
+++ b/rosidl_typesupport_c/QUALITY_DECLARATION.md
@@ -1,6 +1,6 @@
 This document is a declaration of software quality for the `rosidl_typesupport_c` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
 
-# `rosidl_typesupport_c` Quality Declaration
+# rosidl_typesupport_c Quality Declaration
 
 The package `rosidl_typesupport_c` claims to be in the **Quality Level 4** category.
 
@@ -65,7 +65,7 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Feature Documentation [3.i]
 
-`rosidl_typesupport_c` does not have any feature documentation and it will need to be added for higher quality levels.
+`rosidl_typesupport_c` has feature documentation and it is publicly [hosted](docs/FEATURES.md).
 
 ### Public API Documentation [3.ii]
 

--- a/rosidl_typesupport_c/README.md
+++ b/rosidl_typesupport_c/README.md
@@ -2,5 +2,10 @@
 
 `rosidl_typesupport_c` provides functionality for getting the associated message or service c typesupport handler functions.
 
-* `include/rosidl_typesupport_c/message_type_support_dispatch.h`: Look up message type support handle functions from available libraries.
-* `include/rosidl_typesupport_c/service_type_support_dispatch.h`: Look up service type support handle functions from available libraries.
+## Features
+
+The features provided by `rosidl_typesupport_c` are described in [FEATURES](docs/FEATURES.md).
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rosidl_typesupport_c/docs/FEATURES.md
+++ b/rosidl_typesupport_c/docs/FEATURES.md
@@ -1,0 +1,18 @@
+# `rosidl_typesupport_c` features
+
+`rosidl_typesupport_c` provides a Python generator [executable](bin/rosidl_typesupport_c) based on Empy to create rosidl C source files.
+
+The templates utilized by this generator executable are located in resource and generate source files for:
+* [Messages](resource/msg__type_support.cpp.em)
+* [Services](resource/srv__type_support.cpp.em)
+* [Actions](resource/action__type_support.c.em)
+
+The generator also generates a [visibility_control](resource/rosidl_typesupport_c__visibility_control.h.in) header based on https://gcc.gnu.org/wiki/Visibility.
+
+`rosidl_typesupport_c` defines a typesupport identifier, which is declared in [identifier.h](include/rosidl_typesupport_c/identifier.h).
+
+`rosidl_typesupport_c` provides the following functionality for incorporation into generated typesupport source files.
+
+* [message_type_support_dispatch.h](include/rosidl_typesupport_c/message_type_support_dispatch.h): Look up message type support handle functions from available libraries.
+* [service_type_support_dispatch.h](include/rosidl_typesupport_c/service_type_support_dispatch.h): Look up service type support handle functions from available libraries.
+* [type_support_map_t](include/rosidl_typesupport_c/type_support_map_t.h): This defines the lookup of C typesupport handlers.

--- a/rosidl_typesupport_c/docs/FEATURES.md
+++ b/rosidl_typesupport_c/docs/FEATURES.md
@@ -1,18 +1,15 @@
-# `rosidl_typesupport_c` features
+# rosidl_typesupport_c features
 
-`rosidl_typesupport_c` provides a Python generator [executable](bin/rosidl_typesupport_c) based on Empy to create rosidl C source files.
+`rosidl_typesupport_c` provides a Python generator executable, `rosidl_typesupport_c`, based on Empy to create rosidl C source files.
 
-The templates utilized by this generator executable are located in resource and generate source files for:
-* [Messages](resource/msg__type_support.cpp.em)
-* [Services](resource/srv__type_support.cpp.em)
-* [Actions](resource/action__type_support.c.em)
+The templates utilized by this generator executable are located in the `resource` directory and generate source files for messages, services and actions.
 
-The generator also generates a [visibility_control](resource/rosidl_typesupport_c__visibility_control.h.in) header based on https://gcc.gnu.org/wiki/Visibility.
+The generator also generates a visibility_control header based on https://gcc.gnu.org/wiki/Visibility.
 
-`rosidl_typesupport_c` defines a typesupport identifier, which is declared in [identifier.h](include/rosidl_typesupport_c/identifier.h).
+`rosidl_typesupport_c` defines a typesupport identifier, which is declared in `identifier.h`.
 
 `rosidl_typesupport_c` provides the following functionality for incorporation into generated typesupport source files.
 
-* [message_type_support_dispatch.h](include/rosidl_typesupport_c/message_type_support_dispatch.h): Look up message type support handle functions from available libraries.
-* [service_type_support_dispatch.h](include/rosidl_typesupport_c/service_type_support_dispatch.h): Look up service type support handle functions from available libraries.
-* [type_support_map_t](include/rosidl_typesupport_c/type_support_map_t.h): This defines the lookup of C typesupport handlers.
+* `message_type_support_dispatch.h`: Look up message type support handle functions from available libraries.
+* `service_type_support_dispatch.h`: Look up service type support handle functions from available libraries.
+* `type_support_map_t.h`: This defines the lookup of C typesupport handlers.

--- a/rosidl_typesupport_cpp/Doxyfile
+++ b/rosidl_typesupport_cpp/Doxyfile
@@ -5,7 +5,7 @@ PROJECT_NUMBER         = master
 PROJECT_BRIEF          = "ROSIDL C++ Typesupport"
 
 # Use these lines to include the generated logging.hpp (update install path if needed)
-INPUT                  = README.md ./include ./docs
+INPUT                  = README.md ./include ./docs ./QUALITY_DECLARATION.md
 USE_MDFILE_AS_MAINPAGE = README.md
 
 RECURSIVE              = YES

--- a/rosidl_typesupport_cpp/Doxyfile
+++ b/rosidl_typesupport_cpp/Doxyfile
@@ -5,7 +5,7 @@ PROJECT_NUMBER         = master
 PROJECT_BRIEF          = "ROSIDL C++ Typesupport"
 
 # Use these lines to include the generated logging.hpp (update install path if needed)
-INPUT                  = README.md ./include
+INPUT                  = README.md ./include ./docs
 USE_MDFILE_AS_MAINPAGE = README.md
 
 RECURSIVE              = YES
@@ -19,11 +19,10 @@ GENERATE_LATEX         = NO
 ENABLE_PREPROCESSING   = YES
 MACRO_EXPANSION        = YES
 EXPAND_ONLY_PREDEF     = YES
-PREDEFINED             = ROSIDL_TYPESUPPORT_C_PUBLIC=
+PREDEFINED             = ROSIDL_TYPESUPPORT_CPP_PUBLIC=
 
 # Tag files that do not exist will produce a warning and cross-project linking will not work.
 TAGFILES += "../../../../doxygen_tag_files/cppreference-doxygen-web.tag.xml=http://en.cppreference.com/w/"
-# TODO(brawner) uncomment when rosidl_runtime_c docs are created
-# TAGFILES += "../../../../doxygen_tag_files/rosidl_runtime_c.tag=http://docs.ros2.org/latest/api/rosidl_runtime_c/"
+TAGFILES += "../../../../doxygen_tag_files/rosidl_runtime_c.tag=http://docs.ros2.org/latest/api/rosidl_runtime_c/"
 # Uncomment to generate tag files for cross-project linking.
-#GENERATE_TAGFILE = "../../../../doxygen_tag_files/rclcpp.tag"
+#GENERATE_TAGFILE = "../../../../doxygen_tag_files/rosidl_typesupport_cpp.tag"

--- a/rosidl_typesupport_cpp/QUALITY_DECLARATION.md
+++ b/rosidl_typesupport_cpp/QUALITY_DECLARATION.md
@@ -1,6 +1,6 @@
 This document is a declaration of software quality for the `rosidl_typesupport_cpp` package, based on the guidelines in [REP-2004](https://www.ros.org/reps/rep-2004.html).
 
-# `rosidl_typesupport_cpp` Quality Declaration
+# rosidl_typesupport_cpp Quality Declaration
 
 The package `rosidl_typesupport_cpp` claims to be in the **Quality Level 4** category.
 
@@ -64,7 +64,7 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Feature Documentation [3.i]
 
-`rosidl_typesupport_cpp` does not have any feature documentation and it will need to be added for higher quality levels.
+`rosidl_typesupport_cpp` has feature documentation and it is publicly [hosted](docs/FEATURES.md).
 
 ### Public API Documentation [3.ii]
 

--- a/rosidl_typesupport_cpp/README.md
+++ b/rosidl_typesupport_cpp/README.md
@@ -2,5 +2,10 @@
 
 `rosidl_typesupport_cpp` provides functionality for getting the associated message or service c++ typesupport handler functions.
 
-* `include/rosidl_typesupport_cpp/message_type_support_dispatch.hpp`: Look up message type support handle functions from available libraries.
-* `include/rosidl_typesupport_cpp/service_type_support_dispatch.hpp`: Look up service type support handle functions from available libraries.
+## Features
+
+The features provided by `rosidl_typesupport_c` are described in [FEATURES](docs/FEATURES.md).
+
+## Quality Declaration
+
+This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rosidl_typesupport_cpp/docs/FEATURES.md
+++ b/rosidl_typesupport_cpp/docs/FEATURES.md
@@ -1,0 +1,16 @@
+# `rosidl_typesupport_cpp` features
+
+`rosidl_typesupport_cpp` provides a Python generator [executable](bin/rosidl_typesupport_cpp) based on Empy to create rosidl C++ source files.
+
+The templates utilized by this generator executable are located in resource and generate source files for:
+* [Messages](resource/msg__type_support.cpp.em)
+* [Services](resource/srv__type_support.cpp.em)
+* [Actions](resource/action__type_support.cpp.em)
+
+`rosidl_typesupport_cpp` defines a typesupport identifier, which is declared in [identifier.hpp](include/rosidl_typesupport_c/identifier.hpp).
+
+`rosidl_typesupport_cpp` provides the following functionality for incorporation into generated typesupport source files.
+
+* [message_type_support_dispatch.hpp](include/rosidl_typesupport_c/message_type_support_dispatch.hpp): Look up message type support handle functions from available libraries.
+* [service_type_support_dispatch.hpp](include/rosidl_typesupport_c/service_type_support_dispatch.hpp): Look up service type support handle functions from available libraries.
+* [type_support_map_t.hpp](include/rosidl_typesupport_c/type_support_map_t.hpp): This defines the lookup of C++ typesupport handlers.

--- a/rosidl_typesupport_cpp/docs/FEATURES.md
+++ b/rosidl_typesupport_cpp/docs/FEATURES.md
@@ -1,16 +1,13 @@
-# `rosidl_typesupport_cpp` features
+# rosidl_typesupport_cpp features
 
-`rosidl_typesupport_cpp` provides a Python generator [executable](bin/rosidl_typesupport_cpp) based on Empy to create rosidl C++ source files.
+`rosidl_typesupport_cpp` provides a Python generator executable, `rosidl_typesupport_cpp`, based on Empy to create rosidl C++ source files.
 
-The templates utilized by this generator executable are located in resource and generate source files for:
-* [Messages](resource/msg__type_support.cpp.em)
-* [Services](resource/srv__type_support.cpp.em)
-* [Actions](resource/action__type_support.cpp.em)
+The templates utilized by this generator executable are located in the `resource` directory and generate source files for messages, services and actions.
 
-`rosidl_typesupport_cpp` defines a typesupport identifier, which is declared in [identifier.hpp](include/rosidl_typesupport_c/identifier.hpp).
+`rosidl_typesupport_cpp` defines a typesupport identifier, which is declared in `identifier.hpp`.
 
 `rosidl_typesupport_cpp` provides the following functionality for incorporation into generated typesupport source files.
 
-* [message_type_support_dispatch.hpp](include/rosidl_typesupport_c/message_type_support_dispatch.hpp): Look up message type support handle functions from available libraries.
-* [service_type_support_dispatch.hpp](include/rosidl_typesupport_c/service_type_support_dispatch.hpp): Look up service type support handle functions from available libraries.
-* [type_support_map_t.hpp](include/rosidl_typesupport_c/type_support_map_t.hpp): This defines the lookup of C++ typesupport handlers.
+* `message_type_support_dispatch.hpp`: Look up message type support handle functions from available libraries.
+* `service_type_support_dispatch.hpp`: Look up service type support handle functions from available libraries.
+* `type_support_map_t.hpp`: This defines the lookup of C++ typesupport handlers.


### PR DESCRIPTION
This fills out the feature documentation in the READMEs of these two packages. I'm also uncommenting the TAGFILES for rosidl_runtime_c/cpp which have been recently added.