### PR TITLE
Force extension points to be registered in order

### DIFF
--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(NOT rosidl_generator_c_FOUND)
+  message(FATAL_ERROR
+    "Executing rosidl_typesupport_c extension point when rosidl_generator_c wasn't found."
+    "Make sure rosidl_generator_c is installed.")
+endif()
+
 set(_output_path
   "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_c/${PROJECT_NAME}")
 set(_generated_sources "")

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -14,8 +14,8 @@
 
 if(NOT rosidl_generator_c_FOUND)
   message(FATAL_ERROR
-    "Executing rosidl_typesupport_c extension point when rosidl_generator_c wasn't found."
-    "Make sure rosidl_generator_c is installed.")
+    "'rosidl_generator_c' not found when executing "
+    "'rosidl_typesupport_c' extension.")
 endif()
 
 set(_output_path

--- a/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
+++ b/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
@@ -4,9 +4,16 @@
 # use the same type of library
 set(rosidl_typesupport_c_LIBRARY_TYPE "@rosidl_typesupport_c_LIBRARY_TYPE@")
 
-find_package(ament_cmake_core QUIET REQUIRED)
-
 include("${rosidl_typesupport_c_DIR}/get_used_typesupports.cmake")
+
+find_package(ament_cmake_core QUIET REQUIRED)
+get_used_typesupports(_typesupports "rosidl_typesupport_c")
+
+# Make sure extension points are registered in order
+find_package(rosidl_generator_c QUIET REQUIRED)
+foreach(_typesupport ${_typesupports})
+  find_package(${_typesupport} QUIET REQUIRED)
+endforeach()
 
 ament_register_extension(
   "rosidl_generate_idl_interfaces"

--- a/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
+++ b/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
@@ -5,8 +5,6 @@
 set(rosidl_typesupport_c_LIBRARY_TYPE "@rosidl_typesupport_c_LIBRARY_TYPE@")
 
 include("${rosidl_typesupport_c_DIR}/get_used_typesupports.cmake")
-
-find_package(ament_cmake_core QUIET REQUIRED)
 get_used_typesupports(_typesupports "rosidl_typesupport_c")
 
 # Make sure extension points are registered in order
@@ -15,6 +13,7 @@ foreach(_typesupport ${_typesupports})
   find_package(${_typesupport} QUIET)
 endforeach()
 
+find_package(ament_cmake_core QUIET REQUIRED)
 ament_register_extension(
   "rosidl_generate_idl_interfaces"
   "rosidl_typesupport_c"

--- a/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
+++ b/rosidl_typesupport_c/rosidl_typesupport_c-extras.cmake.in
@@ -10,9 +10,9 @@ find_package(ament_cmake_core QUIET REQUIRED)
 get_used_typesupports(_typesupports "rosidl_typesupport_c")
 
 # Make sure extension points are registered in order
-find_package(rosidl_generator_c QUIET REQUIRED)
+find_package(rosidl_generator_c QUIET)
 foreach(_typesupport ${_typesupports})
-  find_package(${_typesupport} QUIET REQUIRED)
+  find_package(${_typesupport} QUIET)
 endforeach()
 
 ament_register_extension(

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if(NOT rosidl_generator_cpp_FOUND)
+  message(FATAL_ERROR
+    "Executing rosidl_typesupport_cpp extension point when rosidl_generator_cpp wasn't found."
+    "Make sure rosidl_generator_cpp is installed.")
+endif()
+
 set(_output_path
   "${CMAKE_CURRENT_BINARY_DIR}/rosidl_typesupport_cpp/${PROJECT_NAME}")
 set(_generated_sources "")

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -14,8 +14,8 @@
 
 if(NOT rosidl_generator_cpp_FOUND)
   message(FATAL_ERROR
-    "Executing rosidl_typesupport_cpp extension point when rosidl_generator_cpp wasn't found."
-    "Make sure rosidl_generator_cpp is installed.")
+    "'rosidl_generator_cpp' not found when executing "
+    "'rosidl_typesupport_cpp' extension.")
 endif()
 
 set(_output_path

--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
@@ -5,6 +5,15 @@
 set(rosidl_typesupport_cpp_LIBRARY_TYPE "@rosidl_typesupport_cpp_LIBRARY_TYPE@")
 
 find_package(ament_cmake_core QUIET REQUIRED)
+find_package(rosidl_typesupport_c QUIET REQUIRED)
+
+get_used_typesupports(_typesupports "rosidl_typesupport_cpp")
+
+# Make sure extension points are registered in order
+find_package(rosidl_generator_cpp QUIET REQUIRED)
+foreach(_typesupport ${_typesupports})
+  find_package(${_typesupport} QUIET REQUIRED)
+endforeach()
 
 ament_register_extension(
   "rosidl_generate_idl_interfaces"

--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
@@ -10,9 +10,9 @@ find_package(rosidl_typesupport_c QUIET REQUIRED)
 get_used_typesupports(_typesupports "rosidl_typesupport_cpp")
 
 # Make sure extension points are registered in order
-find_package(rosidl_generator_cpp QUIET REQUIRED)
+find_package(rosidl_generator_cpp QUIET)
 foreach(_typesupport ${_typesupports})
-  find_package(${_typesupport} QUIET REQUIRED)
+  find_package(${_typesupport} QUIET)
 endforeach()
 
 ament_register_extension(

--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp-extras.cmake.in
@@ -4,9 +4,7 @@
 # use the same type of library
 set(rosidl_typesupport_cpp_LIBRARY_TYPE "@rosidl_typesupport_cpp_LIBRARY_TYPE@")
 
-find_package(ament_cmake_core QUIET REQUIRED)
 find_package(rosidl_typesupport_c QUIET REQUIRED)
-
 get_used_typesupports(_typesupports "rosidl_typesupport_cpp")
 
 # Make sure extension points are registered in order
@@ -15,6 +13,7 @@ foreach(_typesupport ${_typesupports})
   find_package(${_typesupport} QUIET)
 endforeach()
 
+find_package(ament_cmake_core QUIET REQUIRED)
 ament_register_extension(
   "rosidl_generate_idl_interfaces"
   "rosidl_typesupport_cpp"


### PR DESCRIPTION
Similar to https://github.com/ros2/rosidl/pull/485.
Required by https://github.com/ament/ament_cmake/pull/256.