### PR TITLE
Update API documentation and QDs

### DIFF
--- a/rosidl_typesupport_c/QUALITY_DECLARATION.md
+++ b/rosidl_typesupport_c/QUALITY_DECLARATION.md
@@ -69,7 +69,7 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Public API Documentation [3.ii]
 
-`rosidl_typesupport_c` does not currently have public API documentation.
+`rosidl_typesupport_c` has documentation of its public API, but it is not yet hosted.
 
 ### License [3.iii]
 

--- a/rosidl_typesupport_cpp/QUALITY_DECLARATION.md
+++ b/rosidl_typesupport_cpp/QUALITY_DECLARATION.md
@@ -68,7 +68,7 @@ All pull requests must resolve related documentation changes before merging.
 
 ### Public API Documentation [3.ii]
 
-`rosidl_typesupport_cpp` does not currently have public API documentation.
+`rosidl_typesupport_cpp` has documentation of its public API, but it is not yet hosted.
 
 ### License [3.iii]
 


### PR DESCRIPTION
Upon review, the API documentation is actually sufficient in this package. This now brings up the documentation status of this package to QL 1 pending public hosting of the API docs.

Signed-off-by: Stephen Brawner <brawner@gmail.com>