### PR TITLE
Addresses test failures in release mode

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -58,6 +58,9 @@ if(BUILD_TESTING)
   add_library(rosidl_typesupport_c__test_type_support1
     test/test_type_support.c)
   target_include_directories(rosidl_typesupport_c__test_type_support1 PRIVATE include)
+  ament_target_dependencies(rosidl_typesupport_c__test_type_support1
+    "rosidl_runtime_c"
+  )
   add_custom_command(TARGET rosidl_typesupport_c__test_type_support1 POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_FILE:rosidl_typesupport_c__test_type_support1>
@@ -67,6 +70,9 @@ if(BUILD_TESTING)
   add_library(rosidl_typesupport_c__test_type_support2
     test/test_type_support.c)
   target_include_directories(rosidl_typesupport_c__test_type_support2 PRIVATE include)
+  ament_target_dependencies(rosidl_typesupport_c__test_type_support2
+    "rosidl_runtime_c"
+  )
   add_custom_command(TARGET rosidl_typesupport_c__test_type_support2 POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_FILE:rosidl_typesupport_c__test_type_support2>

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -25,7 +25,10 @@ constexpr const char * identifiers[map_size] = {
 };
 
 constexpr const char * symbols[map_size] = {
-  "test_type_support", "test_type_support2", "test_type_support3", "test_type_support4"
+  "test_message_type_support",
+  "test_message_type_support2",
+  "test_message_type_support3",
+  "test_message_type_support4"
 };
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
@@ -88,10 +91,17 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
   type_support_c_identifier.data = &support_map;
 
   // Successfully load library and find symbols
-  EXPECT_NE(
-    rosidl_typesupport_c__get_message_typesupport_handle_function(
-      &type_support_c_identifier,
-      "test_type_support1"), nullptr);
+  auto * result = rosidl_typesupport_c__get_message_typesupport_handle_function(
+    &type_support_c_identifier,
+    "test_type_support1");
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(support_map.data[0], nullptr);
+  auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
+  auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+  ASSERT_NE(lib, nullptr);
+  EXPECT_TRUE(lib->has_symbol("test_message_type_support"));
+  auto * sym = lib->get_symbol("test_message_type_support");
+  ASSERT_NE(sym, nullptr);
 
   // Loads library, but symbol doesn't exist
   EXPECT_EQ(

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -25,7 +25,10 @@ constexpr const char * identifiers[map_size] = {
 };
 
 constexpr const char * symbols[map_size] = {
-  "test_type_support", "test_type_support2", "test_type_support3", "test_type_support4"
+  "test_service_type_support",
+  "test_service_type_support2",
+  "test_service_type_support3",
+  "test_service_type_support4"
 };
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
@@ -88,10 +91,17 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
   type_support_c_identifier.data = &support_map;
 
   // Successfully load library and find symbols
-  EXPECT_NE(
-    rosidl_typesupport_c__get_service_typesupport_handle_function(
-      &type_support_c_identifier,
-      "test_type_support1"), nullptr);
+  auto * result = rosidl_typesupport_c__get_service_typesupport_handle_function(
+    &type_support_c_identifier,
+    "test_type_support1");
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(support_map.data[0], nullptr);
+  auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
+  auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+  ASSERT_NE(lib, nullptr);
+  EXPECT_TRUE(lib->has_symbol("test_service_type_support"));
+  auto * sym = lib->get_symbol("test_service_type_support");
+  ASSERT_NE(sym, nullptr);
 
   // Loads library, but symbol doesn't exist
   EXPECT_EQ(

--- a/rosidl_typesupport_c/test/test_type_support.c
+++ b/rosidl_typesupport_c/test/test_type_support.c
@@ -14,15 +14,29 @@
 
 // Provide a symbol so they can be checked with get_typesupport_handle_function()
 
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
 #include "rosidl_typesupport_c/visibility_control.h"
 
-// If ROSIDL_TYPESUPPORT_CPP_PUBLIC is used, it selects dllimport instead of dllexport, but the
+// If ROSIDL_TYPESUPPORT_C_PUBLIC is used, it selects dllimport instead of dllexport, but the
 // function still needs to be defined separately. Windows has gotten picky with its compiler
 // warnings recently.
 #if defined _WIN32 || defined __CYGWIN__
-__declspec(dllexport) void test_type_support();
+__declspec(dllexport) const rosidl_message_type_support_t * test_message_type_support();
+__declspec(dllexport) const rosidl_service_type_support_t * test_service_type_support();
 #else
-void test_type_support();
+const rosidl_message_type_support_t * test_message_type_support();
+const rosidl_service_type_support_t * test_service_type_support();
 #endif
 
-void test_type_support() {}
+static const rosidl_message_type_support_t message_type_support = {
+  0, 0, 0
+};
+
+static const rosidl_service_type_support_t service_type_support = {
+  0, 0, 0
+};
+
+const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}
+
+const rosidl_service_type_support_t * test_service_type_support() {return &service_type_support;}

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -56,6 +56,9 @@ if(BUILD_TESTING)
   add_library(rosidl_typesupport_cpp__test_type_support1
     test/test_type_support.cpp)
   target_include_directories(rosidl_typesupport_cpp__test_type_support1 PRIVATE include)
+  ament_target_dependencies(rosidl_typesupport_cpp__test_type_support1
+    "rosidl_runtime_c"
+  )
   add_custom_command(TARGET rosidl_typesupport_cpp__test_type_support1 POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_FILE:rosidl_typesupport_cpp__test_type_support1>
@@ -65,6 +68,9 @@ if(BUILD_TESTING)
   add_library(rosidl_typesupport_cpp__test_type_support2
     test/test_type_support.cpp)
   target_include_directories(rosidl_typesupport_cpp__test_type_support2 PRIVATE include)
+  ament_target_dependencies(rosidl_typesupport_cpp__test_type_support2
+    "rosidl_runtime_c"
+  )
   add_custom_command(TARGET rosidl_typesupport_cpp__test_type_support2 POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy
     $<TARGET_FILE:rosidl_typesupport_cpp__test_type_support2>

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -82,7 +82,6 @@ get_typesupport_handle_function(
       }
       void * sym = lib->get_symbol(map->symbol_name[i]);
 
-
       typedef const TypeSupport * (* funcSignature)(void);
       funcSignature func = reinterpret_cast<funcSignature>(sym);
       const TypeSupport * ts = func();

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -25,7 +25,10 @@ constexpr const char * identifiers[map_size] = {
 };
 
 constexpr const char * symbols[map_size] = {
-  "test_type_support", "test_type_support2", "test_type_support3", "test_type_support4"
+  "test_message_type_support",
+  "test_message_type_support2",
+  "test_message_type_support3",
+  "test_message_type_support4"
 };
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
@@ -88,10 +91,17 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
   type_support_cpp_identifier.data = &support_map;
 
   // Successfully load library and find symbols
-  EXPECT_NE(
-    rosidl_typesupport_cpp::get_message_typesupport_handle_function(
-      &type_support_cpp_identifier,
-      "test_type_support1"), nullptr);
+  auto * result = rosidl_typesupport_cpp::get_message_typesupport_handle_function(
+    &type_support_cpp_identifier,
+    "test_type_support1");
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(support_map.data[0], nullptr);
+  auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
+  auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+  ASSERT_NE(lib, nullptr);
+  EXPECT_TRUE(lib->has_symbol("test_message_type_support"));
+  auto * sym = lib->get_symbol("test_message_type_support");
+  ASSERT_NE(sym, nullptr);
 
   // Loads library, but symbol doesn't exist
   EXPECT_EQ(

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -102,6 +102,9 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
   EXPECT_TRUE(lib->has_symbol("test_message_type_support"));
   auto * sym = lib->get_symbol("test_message_type_support");
   ASSERT_NE(sym, nullptr);
+  if (library_array[0] != nullptr) {
+    delete library_array[0];
+  }
 
   // Loads library, but symbol doesn't exist
   EXPECT_EQ(

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -25,7 +25,10 @@ constexpr const char * identifiers[map_size] = {
 };
 
 constexpr const char * symbols[map_size] = {
-  "test_type_support", "test_type_support2", "test_type_support3", "test_type_support4"
+  "test_service_type_support",
+  "test_service_type_support2",
+  "test_service_type_support3",
+  "test_service_type_support4"
 };
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
@@ -44,7 +47,7 @@ type_support_map_t get_typesupport_map(void ** library_array)
   };
 }
 
-TEST(TestMessageTypeSupportDispatch, get_handle_function) {
+TEST(TestServiceTypeSupportDispatch, get_handle_function) {
   // Both arguments are nullptrs
   EXPECT_DEATH(
     rosidl_typesupport_cpp::get_service_typesupport_handle_function(nullptr, nullptr), "");
@@ -88,10 +91,17 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
   type_support_cpp_identifier.data = &support_map;
 
   // Successfully load library and find symbols
-  EXPECT_NE(
-    rosidl_typesupport_cpp::get_service_typesupport_handle_function(
-      &type_support_cpp_identifier,
-      "test_type_support1"), nullptr);
+  auto * result = rosidl_typesupport_cpp::get_service_typesupport_handle_function(
+    &type_support_cpp_identifier,
+    "test_type_support1");
+  ASSERT_NE(result, nullptr);
+  ASSERT_NE(support_map.data[0], nullptr);
+  auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
+  auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+  ASSERT_NE(lib, nullptr);
+  EXPECT_TRUE(lib->has_symbol("test_service_type_support"));
+  auto * sym = lib->get_symbol("test_service_type_support");
+  ASSERT_NE(sym, nullptr);
 
   // Loads library, but symbol doesn't exist
   EXPECT_EQ(

--- a/rosidl_typesupport_cpp/test/test_type_support.cpp
+++ b/rosidl_typesupport_cpp/test/test_type_support.cpp
@@ -14,6 +14,8 @@
 
 // Provide a symbol so they can be checked with get_typesupport_handle_function()
 
+#include "rosidl_runtime_c/message_type_support_struct.h"
+#include "rosidl_runtime_c/service_type_support_struct.h"
 #include "rosidl_typesupport_cpp/visibility_control.h"
 
 #ifdef __cplusplus
@@ -25,12 +27,24 @@ extern "C"
 // function still needs to be defined separately. Windows has gotten picky with its compiler
 // warnings recently.
 #if defined _WIN32 || defined __CYGWIN__
-__declspec(dllexport) void test_type_support();
+__declspec(dllexport) const rosidl_message_type_support_t * test_message_type_support();
+__declspec(dllexport) const rosidl_service_type_support_t * test_service_type_support();
 #else
-void test_type_support();
+const rosidl_message_type_support_t * test_message_type_support();
+const rosidl_service_type_support_t * test_service_type_support();
 #endif
 
-void test_type_support() {}
+static const rosidl_message_type_support_t message_type_support = {
+  0, 0, 0
+};
+
+static const rosidl_service_type_support_t service_type_support = {
+  0, 0, 0
+};
+
+const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}
+
+const rosidl_service_type_support_t * test_service_type_support() {return &service_type_support;}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
These tests were behaving differently under release mode than debug mode, which is how they were originally tested and evaluated. I'm not entirely sure of the full cause of the issue or why it worked in debug mode but not release. As far as I can tell the functions defined in `test_type_support.c` and `test_type_support.cpp` were simple void functions, but after loading their libraries` type_support_dispatch` called those functions and assigned their result to a pointer which was then returned, and that always returned null on gcc release. Even stranger, printing out the address of sym with std::cout in `type_support_dispatch` allowed the test to pass. It seems likely to me that the original code was causing undefined behavior and gcc's optimizations caused a different result than debug mode. 

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=10863)](http://ci.ros2.org/job/ci_linux/10863/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=6228)](http://ci.ros2.org/job/ci_linux-aarch64/6228/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=8849)](http://ci.ros2.org/job/ci_osx/8849/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=10754)](http://ci.ros2.org/job/ci_windows/10754/)

Signed-off-by: Stephen Brawner <stephenbrawner@verbsurgical.com>