### PR TITLE
Add fault injection macros and unit tests

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -101,7 +101,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_service_type_support
       ${PROJECT_NAME}
     )
-  target_compile_definitions(test_service_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
+    target_compile_definitions(test_service_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   # Test type_support_dispatch throws runtime error when trying to load this "library"

--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -89,6 +89,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_message_type_support
       ${PROJECT_NAME}
     )
+    target_compile_definitions(test_message_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   ament_add_gtest(test_service_type_support test/test_service_type_support_dispatch.cpp
@@ -100,6 +101,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_service_type_support
       ${PROJECT_NAME}
     )
+  target_compile_definitions(test_service_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   # Test type_support_dispatch throws runtime error when trying to load this "library"

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -142,12 +142,12 @@ TEST(TestMessageTypeSupportDispatch, get_message_typesupport_maybe_fail_test)
 
   RCUTILS_FAULT_INJECTION_TEST(
   {
-    try {
-      auto * result = rosidl_typesupport_c__get_message_typesupport_handle_function(
-        &type_support_c_identifier,
-        "test_type_support1");
-      EXPECT_NE(result, nullptr);
-    } catch (...) {
+    auto * result = rosidl_typesupport_c__get_message_typesupport_handle_function(
+      &type_support_c_identifier,
+      "test_type_support1");
+    if (nullptr == result) {
+      EXPECT_TRUE(rcutils_error_is_set());
+      rcutils_reset_error();
     }
   });
 }

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <rcutils/testing/fault_injection.h>
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/error_handling.h"
 #include "rosidl_typesupport_c/identifier.h"
@@ -129,4 +130,24 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
       "test_type_support4"), nullptr);
   EXPECT_TRUE(rcutils_error_is_set());
   rcutils_reset_error();
+}
+
+TEST(TestMessageTypeSupportDispatch, get_message_typesupport_maybe_fail_test)
+{
+  rosidl_message_type_support_t type_support_c_identifier =
+    get_rosidl_message_type_support(rosidl_typesupport_c__typesupport_identifier);
+  rcpputils::SharedLibrary * library_array[map_size] = {nullptr, nullptr, nullptr};
+  type_support_map_t support_map = get_typesupport_map(reinterpret_cast<void **>(&library_array));
+  type_support_c_identifier.data = &support_map;
+
+  RCUTILS_FAULT_INJECTION_TEST(
+  {
+    try {
+      auto * result = rosidl_typesupport_c__get_message_typesupport_handle_function(
+        &type_support_c_identifier,
+        "test_type_support1");
+      EXPECT_NE(result, nullptr);
+    } catch (...) {
+    }
+  });
 }

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -142,12 +142,12 @@ TEST(TestServiceTypeSupportDispatch, get_service_typesupport_maybe_fail_test)
 
   RCUTILS_FAULT_INJECTION_TEST(
   {
-    try {
-      auto * result = rosidl_typesupport_c__get_service_typesupport_handle_function(
-        &type_support_c_identifier,
-        "test_type_support1");
-      EXPECT_NE(result, nullptr);
-    } catch (...) {
+    auto * result = rosidl_typesupport_c__get_service_typesupport_handle_function(
+      &type_support_c_identifier,
+      "test_type_support1");
+    if (nullptr == result) {
+      EXPECT_TRUE(rcutils_error_is_set());
+      rcutils_reset_error();
     }
   });
 }

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include <rcutils/testing/fault_injection.h>
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/error_handling.h"
 #include "rosidl_typesupport_c/identifier.h"
@@ -129,4 +130,24 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
       "test_type_support4"), nullptr);
   EXPECT_TRUE(rcutils_error_is_set());
   rcutils_reset_error();
+}
+
+TEST(TestServiceTypeSupportDispatch, get_service_typesupport_maybe_fail_test)
+{
+  rosidl_service_type_support_t type_support_c_identifier =
+    get_rosidl_service_type_support(rosidl_typesupport_c__typesupport_identifier);
+  rcpputils::SharedLibrary * library_array[map_size] = {nullptr, nullptr, nullptr};
+  type_support_map_t support_map = get_typesupport_map(reinterpret_cast<void **>(&library_array));
+  type_support_c_identifier.data = &support_map;
+
+  RCUTILS_FAULT_INJECTION_TEST(
+  {
+    try {
+      auto * result = rosidl_typesupport_c__get_service_typesupport_handle_function(
+        &type_support_c_identifier,
+        "test_type_support1");
+      EXPECT_NE(result, nullptr);
+    } catch (...) {
+    }
+  });
 }

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -85,6 +85,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_message_type_support
       ${PROJECT_NAME}
     )
+  target_compile_definitions(test_message_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   ament_add_gtest(test_service_type_support test/test_service_type_support_dispatch.cpp
@@ -96,6 +97,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_service_type_support
       ${PROJECT_NAME}
     )
+  target_compile_definitions(test_service_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   # Test type_support_dispatch throws runtime error when trying to load this "library"

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -85,7 +85,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_message_type_support
       ${PROJECT_NAME}
     )
-  target_compile_definitions(test_message_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
+    target_compile_definitions(test_message_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   ament_add_gtest(test_service_type_support test/test_service_type_support_dispatch.cpp
@@ -97,7 +97,7 @@ if(BUILD_TESTING)
     target_link_libraries(test_service_type_support
       ${PROJECT_NAME}
     )
-  target_compile_definitions(test_service_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
+    target_compile_definitions(test_service_type_support PUBLIC RCUTILS_ENABLE_FAULT_INJECTION)
   endif()
 
   # Test type_support_dispatch throws runtime error when trying to load this "library"

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -126,7 +126,7 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
       "test_type_support4"), nullptr);
 }
 
-TEST(TestMessageTypeSupportDispatch, maybe_fail_test)
+TEST(TestMessageTypeSupportDispatch, get_message_typesupport_maybe_fail_test)
 {
   rosidl_message_type_support_t type_support_cpp_identifier =
     get_rosidl_message_type_support(rosidl_typesupport_cpp::typesupport_identifier);

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -142,7 +142,7 @@ TEST(TestMessageTypeSupportDispatch, get_message_typesupport_maybe_fail_test)
         &type_support_cpp_identifier,
         "test_type_support1");
       EXPECT_NE(result, nullptr);
-    } catch (const std::runtime_error & e) {
+    } catch (const std::runtime_error &) {
     } catch (...) {
       ADD_FAILURE() << "Unexpected exception type in fault injection test";
     }

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -142,7 +142,9 @@ TEST(TestMessageTypeSupportDispatch, get_message_typesupport_maybe_fail_test)
         &type_support_cpp_identifier,
         "test_type_support1");
       EXPECT_NE(result, nullptr);
+    } catch (const std::runtime_error & e) {
     } catch (...) {
+      ADD_FAILURE() << "Unexpected exception type in fault injection test";
     }
   });
 }

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include "rcutils/testing/fault_injection.h"
 #include "rcpputils/shared_library.hpp"
 #include "rosidl_typesupport_cpp/identifier.hpp"
 #include "rosidl_typesupport_cpp/message_type_support_dispatch.hpp"
@@ -123,4 +124,25 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
     rosidl_typesupport_cpp::get_message_typesupport_handle_function(
       &type_support_cpp_identifier,
       "test_type_support4"), nullptr);
+}
+
+TEST(TestMessageTypeSupportDispatch, maybe_fail_test)
+{
+  rosidl_message_type_support_t type_support_cpp_identifier =
+    get_rosidl_message_type_support(rosidl_typesupport_cpp::typesupport_identifier);
+  rcpputils::SharedLibrary * library_array[map_size] = {nullptr, nullptr, nullptr};
+  type_support_map_t support_map = get_typesupport_map(reinterpret_cast<void **>(&library_array));
+  type_support_cpp_identifier.data = &support_map;
+
+  RCUTILS_FAULT_INJECTION_TEST(
+  {
+    // load library and find symbols
+    try {
+      auto * result = rosidl_typesupport_cpp::get_message_typesupport_handle_function(
+        &type_support_cpp_identifier,
+        "test_type_support1");
+      EXPECT_NE(result, nullptr);
+    } catch (...) {
+    }
+  });
 }

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -123,7 +123,7 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
       "test_type_support4"), nullptr);
 }
 
-TEST(TestServiceTypeSupportDispatch, maybe_fail_test)
+TEST(TestServiceTypeSupportDispatch, get_service_typesupport_maybe_fail_test)
 {
   rosidl_service_type_support_t type_support_cpp_identifier =
     get_rosidl_service_type_support(rosidl_typesupport_cpp::typesupport_identifier);

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -139,6 +139,7 @@ TEST(TestServiceTypeSupportDispatch, get_service_typesupport_maybe_fail_test)
         &type_support_cpp_identifier,
         "test_type_support1");
       EXPECT_NE(result, nullptr);
+    } catch (const std::runtime_error &) {
     } catch (...) {
     }
   });

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
+#include "rcutils/testing/fault_injection.h"
 #include "rcpputils/shared_library.hpp"
 #include "rosidl_typesupport_cpp/identifier.hpp"
 #include "rosidl_typesupport_cpp/service_type_support_dispatch.hpp"
@@ -120,4 +121,25 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
     rosidl_typesupport_cpp::get_service_typesupport_handle_function(
       &type_support_cpp_identifier,
       "test_type_support4"), nullptr);
+}
+
+TEST(TestServiceTypeSupportDispatch, maybe_fail_test)
+{
+  rosidl_service_type_support_t type_support_cpp_identifier =
+    get_rosidl_service_type_support(rosidl_typesupport_cpp::typesupport_identifier);
+  rcpputils::SharedLibrary * library_array[map_size] = {nullptr, nullptr, nullptr};
+  type_support_map_t support_map = get_typesupport_map(reinterpret_cast<void **>(&library_array));
+  type_support_cpp_identifier.data = &support_map;
+
+  RCUTILS_FAULT_INJECTION_TEST(
+  {
+    // load library and find symbols
+    try {
+      auto * result = rosidl_typesupport_cpp::get_service_typesupport_handle_function(
+        &type_support_cpp_identifier,
+        "test_type_support1");
+      EXPECT_NE(result, nullptr);
+    } catch (...) {
+    }
+  });
 }


### PR DESCRIPTION
This adds unit test macros and fault injection to rosidl_typesupport_c and rosidl_typesupport_cpp. With these fault injections, coverage can get to 100%. I'll post CI results soon.

Signed-off-by: Stephen Brawner <brawner@gmail.com>