### PR TITLE
Remove rethrow in extern c code

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -17,6 +17,7 @@ endif()
 
 find_package(ament_cmake_ros REQUIRED)
 find_package(rcpputils REQUIRED)
+find_package(rcutils REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
 
 ament_export_dependencies(rcpputils)
@@ -42,6 +43,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 
 ament_target_dependencies(${PROJECT_NAME}
   "rcpputils"
+  "rcutils"
   "rosidl_runtime_c"
 )
 ament_export_libraries(${PROJECT_NAME})

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -10,6 +10,7 @@
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
   <depend>rcpputils</depend>
+  <depend>rcutils</depend>
 
   <build_depend>rosidl_runtime_c</build_depend>
   <!--

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -66,13 +66,11 @@ get_typesupport_handle_function(
         try {
           lib = new rcpputils::SharedLibrary(library_path.c_str());
         } catch (const std::runtime_error & e) {
-          throw std::runtime_error(
-                  "Could not load library " + library_path + ": " +
-                  std::string(e.what()));
+          fprintf(stderr, "Could not load library %s: %s\n", library_path.c_str(), e.what());
+          return nullptr;
         } catch (const std::bad_alloc & e) {
-          throw std::runtime_error(
-                  "Could not load library " + library_path + ": " +
-                  std::string(e.what()));
+          fprintf(stderr, "Could not load library %s: %s\n", library_path.c_str(), e.what());
+          return nullptr;
         }
         map->data[i] = lib;
       }

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 #include "rcpputils/shared_library.hpp"
+#include "rcutils/error_handling.h"
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/message_type_support_dispatch.h"
 #include "rosidl_typesupport_c/type_support_map.h"
@@ -83,6 +84,8 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
     rosidl_typesupport_c__get_message_typesupport_handle_function(
       &type_support,
       "different_identifier"), nullptr);
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
 
   rosidl_message_type_support_t type_support_c_identifier =
     get_rosidl_message_type_support(rosidl_typesupport_c__typesupport_identifier);
@@ -108,16 +111,22 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
     rosidl_typesupport_c__get_message_typesupport_handle_function(
       &type_support_c_identifier,
       "test_type_support2"), nullptr);
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
 
   // Library file exists, but loading shared library fails
   EXPECT_EQ(
     rosidl_typesupport_c__get_message_typesupport_handle_function(
       &type_support_c_identifier,
       "test_type_support3"), nullptr);
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
 
   // Library doesn't exist
   EXPECT_EQ(
     rosidl_typesupport_c__get_message_typesupport_handle_function(
       &type_support_c_identifier,
       "test_type_support4"), nullptr);
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
 }

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -110,10 +110,10 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
       "test_type_support2"), nullptr);
 
   // Library file exists, but loading shared library fails
-  EXPECT_THROW(
+  EXPECT_EQ(
     rosidl_typesupport_c__get_message_typesupport_handle_function(
       &type_support_c_identifier,
-      "test_type_support3"), std::runtime_error);
+      "test_type_support3"), nullptr);
 
   // Library doesn't exist
   EXPECT_EQ(

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 #include "rcpputils/shared_library.hpp"
+#include "rcutils/error_handling.h"
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/service_type_support_dispatch.h"
 #include "rosidl_typesupport_c/type_support_map.h"
@@ -83,6 +84,8 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
     rosidl_typesupport_c__get_service_typesupport_handle_function(
       &type_support,
       "different_identifier"), nullptr);
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
 
   rosidl_service_type_support_t type_support_c_identifier =
     get_rosidl_service_type_support(rosidl_typesupport_c__typesupport_identifier);
@@ -108,16 +111,22 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
     rosidl_typesupport_c__get_service_typesupport_handle_function(
       &type_support_c_identifier,
       "test_type_support2"), nullptr);
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
 
   // Library file exists, but loading shared library fails
   EXPECT_EQ(
     rosidl_typesupport_c__get_service_typesupport_handle_function(
       &type_support_c_identifier,
       "test_type_support3"), nullptr);
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
 
   // Library doesn't exist
   EXPECT_EQ(
     rosidl_typesupport_c__get_service_typesupport_handle_function(
       &type_support_c_identifier,
       "test_type_support4"), nullptr);
+  EXPECT_TRUE(rcutils_error_is_set());
+  rcutils_reset_error();
 }

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -110,10 +110,10 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
       "test_type_support2"), nullptr);
 
   // Library file exists, but loading shared library fails
-  EXPECT_THROW(
+  EXPECT_EQ(
     rosidl_typesupport_c__get_service_typesupport_handle_function(
       &type_support_c_identifier,
-      "test_type_support3"), std::runtime_error);
+      "test_type_support3"), nullptr);
 
   // Library doesn't exist
   EXPECT_EQ(


### PR DESCRIPTION
`rosidl_typesupport_c` code had some rethrown exceptions which were inside extern c functions. I believe, but not entirely sure, this is not recommended since there is no way for the C code to handle them and they would otherwise be fatal errors. MSVC's optimizer was also treating this code strangely when I tried to catch the exception from a c++ test and would get different results by adding unrelated changes.

Example failure with fault injection test:
* Windows [![Build Status](https://ci.ros2.org/buildStatus/icon?job=ci_windows&build=11853)](https://ci.ros2.org/job/ci_windows/11853/)

Signed-off-by: Stephen Brawner <brawner@gmail.com>