### PR TITLE
[Foxy backport]: De-deplicate type_support_map.h header

### DIFF
--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -14,6 +14,7 @@ endif()
 find_package(ament_cmake_ros REQUIRED)
 find_package(rcpputils REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
+find_package(rosidl_typesupport_c REQUIRED)
 
 ament_export_dependencies(rcpputils)
 ament_export_dependencies(rosidl_runtime_c)
@@ -41,6 +42,7 @@ target_include_directories(${PROJECT_NAME} PUBLIC
 ament_target_dependencies(${PROJECT_NAME}
   "rcpputils"
   "rosidl_runtime_c"
+  "rosidl_typesupport_c"
 )
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})

--- a/rosidl_typesupport_cpp/include/rosidl_typesupport_cpp/type_support_map.h
+++ b/rosidl_typesupport_cpp/include/rosidl_typesupport_cpp/type_support_map.h
@@ -18,9 +18,6 @@
 // Keep this file not to break API. It was no more than
 // a copy of rosidl_typesupport_c/type_support_map.h
 
-#warning rosidl_typesupport_cpp/type_support_map.h header is deprecated \
-  in favor of rosidl_typesupport_c/type_support_map.h.
-
 #include "rosidl_typesupport_c/type_support_map.h"
 
 #endif  // ROSIDL_TYPESUPPORT_CPP__TYPE_SUPPORT_MAP_H_

--- a/rosidl_typesupport_cpp/include/rosidl_typesupport_cpp/type_support_map.h
+++ b/rosidl_typesupport_cpp/include/rosidl_typesupport_cpp/type_support_map.h
@@ -15,38 +15,12 @@
 #ifndef ROSIDL_TYPESUPPORT_CPP__TYPE_SUPPORT_MAP_H_
 #define ROSIDL_TYPESUPPORT_CPP__TYPE_SUPPORT_MAP_H_
 
-#include <cstddef>
+// Keep this file not to break API. It was no more than
+// a copy of rosidl_typesupport_c/type_support_map.h
 
-#ifdef __cplusplus
-extern "C"
-{
-#endif
+#warning rosidl_typesupport_cpp/type_support_map.h header is deprecated \
+  in favor of rosidl_typesupport_c/type_support_map.h.
 
-/// Contains all available C++ typesupport handles to choose from.
-typedef struct type_support_map_t
-{
-  // TODO(dirk-thomas) const should not be defined for the fields
-  // but should be set for the struct when it is being used
-  // same for rosidl_message_type_support_t et al
-
-  /// Length of the `typesupport_identidentifier`, `symbol_name` and `data` arrays.
-  const size_t size;
-
-  /// The ROS 2 package this is generated from.
-  const char * package_name;
-
-  /// Array of identifiers for the type_supports.
-  const char * const * typesupport_identifier;
-
-  /// Array of symbol names to get the typesupports.
-  const char * const * symbol_name;
-
-  /// Array of pointers to type support handle functions that were successfully found.
-  void ** data;
-} type_support_map_t;
-
-#ifdef __cplusplus
-}
-#endif
+#include "rosidl_typesupport_c/type_support_map.h"
 
 #endif  // ROSIDL_TYPESUPPORT_CPP__TYPE_SUPPORT_MAP_H_

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -11,6 +11,7 @@
 
   <depend>rcpputils</depend>
   <build_depend>rosidl_runtime_c</build_depend>
+  <build_depend>rosidl_typesupport_c</build_depend>
   <!--
   Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_cpp_packages.
   This ensures that binary packages have support for all of these rmw impl. enabled.

--- a/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
@@ -15,8 +15,8 @@ if len(type_supports) != 1:
 header_files.append('rosidl_typesupport_cpp/message_type_support.hpp')
 if len(type_supports) != 1:
     header_files += [
+        'rosidl_typesupport_c/type_support_map.h',
         'rosidl_typesupport_cpp/message_type_support_dispatch.hpp',
-        'rosidl_typesupport_cpp/type_support_map.h',
     ]
 header_files.append('rosidl_typesupport_cpp/visibility_control.h')
 if len(type_supports) != 1:

--- a/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
@@ -31,8 +31,8 @@ if len(type_supports) != 1:
 header_files.append('rosidl_typesupport_cpp/service_type_support.hpp')
 if len(type_supports) != 1:
     header_files += [
+        'rosidl_typesupport_c/type_support_map.h',
         'rosidl_typesupport_cpp/service_type_support_dispatch.hpp',
-        'rosidl_typesupport_cpp/type_support_map.h',
     ]
 header_files.append('rosidl_typesupport_cpp/visibility_control.h')
 if len(type_supports) != 1:

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -25,7 +25,7 @@
 
 #include "rcpputils/find_library.hpp"
 #include "rcpputils/shared_library.hpp"
-#include "rosidl_typesupport_cpp/type_support_map.h"
+#include "rosidl_typesupport_c/type_support_map.h"
 
 namespace rosidl_typesupport_cpp
 {

--- a/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
@@ -13,10 +13,10 @@
 // limitations under the License.
 
 #include "rcpputils/shared_library.hpp"
+#include "rosidl_typesupport_c/type_support_map.h"
 #include "rosidl_typesupport_cpp/identifier.hpp"
 #include "rosidl_typesupport_cpp/message_type_support_dispatch.hpp"
 #include "rosidl_typesupport_cpp/service_type_support_dispatch.hpp"
-#include "rosidl_typesupport_cpp/type_support_map.h"
 
 #include "performance_test_fixture/performance_test_fixture.hpp"
 

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -14,9 +14,9 @@
 
 #include <gtest/gtest.h>
 #include "rcpputils/shared_library.hpp"
+#include "rosidl_typesupport_c/type_support_map.h"
 #include "rosidl_typesupport_cpp/identifier.hpp"
 #include "rosidl_typesupport_cpp/message_type_support_dispatch.hpp"
-#include "rosidl_typesupport_cpp/type_support_map.h"
 
 constexpr size_t map_size = 4u;
 constexpr const char package_name[] = "rosidl_typesupport_cpp";

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -14,9 +14,9 @@
 
 #include <gtest/gtest.h>
 #include "rcpputils/shared_library.hpp"
+#include "rosidl_typesupport_c/type_support_map.h"
 #include "rosidl_typesupport_cpp/identifier.hpp"
 #include "rosidl_typesupport_cpp/service_type_support_dispatch.hpp"
-#include "rosidl_typesupport_cpp/type_support_map.h"
 
 constexpr size_t map_size = 4u;
 constexpr const char package_name[] = "rosidl_typesupport_cpp";


### PR DESCRIPTION
Port of #81 to Foxy branch.

Testing in foxy CI:
* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=12304)](http://ci.ros2.org/job/ci_linux/12304/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=7276)](http://ci.ros2.org/job/ci_linux-aarch64/7276/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10020)](http://ci.ros2.org/job/ci_osx/10020/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=12202)](http://ci.ros2.org/job/ci_windows/12202/)