### PR TITLE
Update QDs to Quality Level 2

### DIFF
--- a/rosidl_typesupport_c/QUALITY_DECLARATION.md
+++ b/rosidl_typesupport_c/QUALITY_DECLARATION.md
@@ -2,7 +2,7 @@ This document is a declaration of software quality for the `rosidl_typesupport_c
 
 # rosidl_typesupport_c Quality Declaration
 
-The package `rosidl_typesupport_c` claims to be in the **Quality Level 3** category.
+The package `rosidl_typesupport_c` claims to be in the **Quality Level 2** category.
 
 Below are the rationales, notes, and caveats for this claim, organized by each requirement listed in the [Package Requirements for Quality Level 3 in REP-2004](https://www.ros.org/reps/rep-2004.html).
 
@@ -117,7 +117,7 @@ Current coverage statistics can be viewed [here](https://ci.ros2.org/job/nightly
 
 ### Performance [4.iv]
 
-`rosidl_typesupport_c` does not currently have performance tests.
+Most recent performance test results can be found [here](http://build.ros2.org/view/Rci/job/Rci__benchmark_ubuntu_focal_amd64/BenchmarkTable/).
 
 ### Linters and Static Analysis [4.v]
 

--- a/rosidl_typesupport_c/README.md
+++ b/rosidl_typesupport_c/README.md
@@ -8,4 +8,4 @@ The features provided by `rosidl_typesupport_c` are described in [FEATURES](docs
 
 ## Quality Declaration
 
-This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.

--- a/rosidl_typesupport_cpp/QUALITY_DECLARATION.md
+++ b/rosidl_typesupport_cpp/QUALITY_DECLARATION.md
@@ -117,7 +117,7 @@ Current coverage statistics can be viewed [here](https://ci.ros2.org/job/nightly
 
 ### Performance [4.iv]
 
-`rosidl_typesupport_cpp` does not currently have performance tests.
+Most recent performance test results can be found [here](http://build.ros2.org/view/Rci/job/Rci__benchmark_ubuntu_focal_amd64/BenchmarkTable/).
 
 ### Linters and Static Analysis [4.v]
 

--- a/rosidl_typesupport_cpp/README.md
+++ b/rosidl_typesupport_cpp/README.md
@@ -4,8 +4,8 @@
 
 ## Features
 
-The features provided by `rosidl_typesupport_c` are described in [FEATURES](docs/FEATURES.md).
+The features provided by `rosidl_typesupport_cpp` are described in [FEATURES](docs/FEATURES.md).
 
 ## Quality Declaration
 
-This package claims to be in the **Quality Level 4** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.
+This package claims to be in the **Quality Level 2** category, see the [Quality Declaration](./QUALITY_DECLARATION.md) for more details.


### PR DESCRIPTION
All the dependencies are level 2 or higher, so these packages can be bumped to level 2.

Also added links to the performance tests added in https://github.com/ros2/rosidl_typesupport/pull/84.