### PR TITLE
Explicitly check lib pointer for null

### DIFF
--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -116,11 +116,8 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+  ASSERT_TRUE(nullptr != lib);
 
-  ASSERT_NE(lib, nullptr);
-  // c-style assert is used to avoid false positive of clang static analysis because it can't
-  // follow gtest asserts
-  assert(nullptr != lib);
   EXPECT_TRUE(lib->has_symbol("test_message_type_support"));
   auto * sym = lib->get_symbol("test_message_type_support");
   ASSERT_NE(sym, nullptr);

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include <rcutils/testing/fault_injection.h>
+
+#include <cassert>
+
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/error_handling.h"
+#include "rcutils/testing/fault_injection.h"
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/message_type_support_dispatch.h"
 #include "rosidl_typesupport_c/type_support_map.h"
@@ -113,7 +116,11 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+
   ASSERT_NE(lib, nullptr);
+  // c-style assert is used to avoid false positive of clang static analysis because it can't
+  // follow gtest asserts
+  assert(nullptr != lib);
   EXPECT_TRUE(lib->has_symbol("test_message_type_support"));
   auto * sym = lib->get_symbol("test_message_type_support");
   ASSERT_NE(sym, nullptr);

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -14,8 +14,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cassert>
-
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/error_handling.h"
 #include "rcutils/testing/fault_injection.h"

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -13,9 +13,12 @@
 // limitations under the License.
 
 #include <gtest/gtest.h>
-#include <rcutils/testing/fault_injection.h>
+
+#include <cassert>
+
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/error_handling.h"
+#include "rcutils/testing/fault_injection.h"
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/service_type_support_dispatch.h"
 #include "rosidl_typesupport_c/type_support_map.h"
@@ -113,7 +116,11 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+
   ASSERT_NE(lib, nullptr);
+  // c-style assert is used to avoid false positive of clang static analysis because it can't
+  // follow gtest asserts
+  assert(nullptr != lib);
   EXPECT_TRUE(lib->has_symbol("test_service_type_support"));
   auto * sym = lib->get_symbol("test_service_type_support");
   ASSERT_NE(sym, nullptr);

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -116,11 +116,8 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+  ASSERT_TRUE(nullptr != lib);
 
-  ASSERT_NE(lib, nullptr);
-  // c-style assert is used to avoid false positive of clang static analysis because it can't
-  // follow gtest asserts
-  assert(nullptr != lib);
   EXPECT_TRUE(lib->has_symbol("test_service_type_support"));
   auto * sym = lib->get_symbol("test_service_type_support");
   ASSERT_NE(sym, nullptr);

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -14,8 +14,6 @@
 
 #include <gtest/gtest.h>
 
-#include <cassert>
-
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/error_handling.h"
 #include "rcutils/testing/fault_injection.h"

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -99,11 +99,8 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+  ASSERT_TRUE(nullptr != lib);
 
-  ASSERT_NE(lib, nullptr);
-  // c-style assert is used to avoid false positive of clang static analysis because it can't
-  // follow gtest asserts
-  assert(nullptr != lib);
   EXPECT_TRUE(lib->has_symbol("test_message_type_support"));
   auto * sym = lib->get_symbol("test_message_type_support");
   ASSERT_NE(sym, nullptr);

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -99,7 +99,11 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+
   ASSERT_NE(lib, nullptr);
+  // c-style assert is used to avoid false positive of clang static analysis because it can't
+  // follow gtest asserts
+  assert(nullptr != lib);
   EXPECT_TRUE(lib->has_symbol("test_message_type_support"));
   auto * sym = lib->get_symbol("test_message_type_support");
   ASSERT_NE(sym, nullptr);

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -99,11 +99,8 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+  ASSERT_TRUE(nullptr != lib);
 
-  ASSERT_NE(lib, nullptr);
-  // c-style assert is used to avoid false positive of clang static analysis because it can't
-  // follow gtest asserts
-  assert(nullptr != lib);
   EXPECT_TRUE(lib->has_symbol("test_service_type_support"));
   auto * sym = lib->get_symbol("test_service_type_support");
   ASSERT_NE(sym, nullptr);

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -99,7 +99,11 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
+
   ASSERT_NE(lib, nullptr);
+  // c-style assert is used to avoid false positive of clang static analysis because it can't
+  // follow gtest asserts
+  assert(nullptr != lib);
   EXPECT_TRUE(lib->has_symbol("test_service_type_support"));
   auto * sym = lib->get_symbol("test_service_type_support");
   ASSERT_NE(sym, nullptr);


### PR DESCRIPTION
This showed up as a false positive from clang static analysis. It's because it doesn't realize that gtest `ASSERT_*` macros will return. Clang does allow for `analyzer_noreturn` annotations to help it understand, but I believe that's only on functions. Clang does recognize standard `assert` statements though, so I thought that would be the simplest solution here.

Example
```
/home/brawner/workspace/ros2_master/src/ros2/rosidl_typesupport/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp:117:15: warning: Called C++ object pointer is null
  EXPECT_TRUE(lib->has_symbol("test_message_type_support"));
              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/home/brawner/workspace/ros2_master/install/gtest_vendor/src/gtest_vendor/include/gtest/gtest.h:1969:23: note: expanded from macro 'EXPECT_TRUE'
  GTEST_TEST_BOOLEAN_(condition, #condition, false, true, \
                      ^~~~~~~~~
/home/brawner/workspace/ros2_master/install/gtest_vendor/src/gtest_vendor/include/gtest/internal/gtest-internal.h:1325:34: note: expanded from macro 'GTEST_TEST_BOOLEAN_'
      ::testing::AssertionResult(expression)) \
                                 ^~~~~~~~~~
```

Signed-off-by: Stephen Brawner <brawner@gmail.com>