### PR TITLE
Defer path resolution of rosidl typesupport libraries to dynamic linker.

### DIFF
--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -22,7 +22,6 @@
 #include <stdexcept>
 #include <string>
 
-#include "rcpputils/find_library.hpp"
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/error_handling.h"
 #include "rcutils/snprintf.h"
@@ -52,40 +51,34 @@ get_typesupport_handle_function(
       rcpputils::SharedLibrary * lib = nullptr;
 
       if (!map->data[i]) {
-        char library_name[1024];
+        char library_basename[1024];
         int ret = rcutils_snprintf(
-          library_name, 1023, "%s__%s",
+          library_basename, 1023, "%s__%s",
           map->package_name, identifier);
         if (ret < 0) {
           RCUTILS_SET_ERROR_MSG("Failed to format library name");
           return nullptr;
         }
 
-        std::string library_path;
+        std::string library_name;
         try {
-          library_path = rcpputils::find_library_path(library_name);
+          library_name = rcpputils::get_platform_library_name(library_basename);
         } catch (const std::runtime_error & e) {
           RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-            "Failed to find library '%s' due to %s",
-            library_name, e.what());
-          return nullptr;
-        }
-
-        if (library_path.empty()) {
-          RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-            "Failed to find library '%s'", library_name);
+            "Failed to compute library name for '%s' due to %s",
+            library_basename, e.what());
           return nullptr;
         }
 
         try {
-          lib = new rcpputils::SharedLibrary(library_path.c_str());
+          lib = new rcpputils::SharedLibrary(library_name);
         } catch (const std::runtime_error & e) {
           RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-            "Could not load library %s: %s", library_name, e.what());
+            "Could not load library %s: %s", library_name.c_str(), e.what());
           return nullptr;
         } catch (const std::bad_alloc & e) {
           RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-            "Could not load library %s: %s", library_name, e.what());
+            "Could not load library %s: %s", library_name.c_str(), e.what());
           return nullptr;
         }
         map->data[i] = lib;


### PR DESCRIPTION
Connected to https://github.com/ros2/rcutils/pull/320. By deferring path resolution to the dynamic linker, RPATHs and RUNPATHs entries as well as LD_LIBRARY_PATH and PATH envvars are dealt with the standard way. Pre-linked and pre-loaded libraries are also honored. 

CI up to `test_communication`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=13267)](http://ci.ros2.org/job/ci_linux/13267/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=8198)](http://ci.ros2.org/job/ci_linux-aarch64/8198/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=10987)](http://ci.ros2.org/job/ci_osx/10987/) (known test failure)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=13310)](http://ci.ros2.org/job/ci_windows/13310/)
