### PR TITLE
Downgrade benign error messages to debug

### DIFF
--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -26,6 +26,7 @@
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/error_handling.h"
 #include "rcutils/snprintf.h"
+#include "rcutils/logging_macros.h"
 #include "rosidl_typesupport_c/identifier.h"
 #include "rosidl_typesupport_c/type_support_map.h"
 

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -110,9 +110,12 @@ get_typesupport_handle_function(
       return ts;
     }
   }
-  RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-    "Handle's typesupport identifier (%s) is not supported by this library",
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rosidl_typesupport_c",
+    "type support `%s` is not used by this library",
     handle->typesupport_identifier);
+  
   return nullptr;
 }
 

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -25,6 +25,7 @@
 #include "rcpputils/shared_library.hpp"
 #include "rcutils/error_handling.h"
 #include "rcutils/snprintf.h"
+#include "rcutils/logging_macros.h"
 #include "rosidl_typesupport_c/type_support_map.h"
 
 namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_cpp/src/type_support_dispatch.hpp
@@ -108,9 +108,12 @@ get_typesupport_handle_function(
       return ts;
     }
   }
-  RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
-    "Handle's typesupport identifier (%s) is not supported by this library",
+
+  RCUTILS_LOG_DEBUG_NAMED(
+    "rosidl_typesupport_cpp",
+    "type support `%s` is not used by this library",
     handle->typesupport_identifier);
+
   return nullptr;
 }
 


### PR DESCRIPTION
This PR changes the severity level of two messages logged by the `get_typesupport_handle_function()` functions in `rosidl_typesupport_c` and `rosidl_typesupport_cpp`, from error to debug.

As far as I can gather from inspecting and debugging the code, these functions are used to look up a specific type support by name, and the current "error condition" is actually just a benign case of an available type support not matching the sought after `identifier`.

I'm still unsure of how the condition is actually triggered, but these error messages show up at times in applications running on `rmw_connextdds` and can become quite intrusive (see [ros2/rmw_connextdds#21](https://github.com/ros2/rmw_connextdds/issues/21) for an example).

After debugging `rmw_connextdds`, I've confirmed that these errors are printed when the RMW tries to look up one of the type supports it needs (e.g. [see here](https://github.com/ros2/rmw_connextdds/blob/master/rmw_connextdds_common/src/common/rmw_type_support.cpp#L537)). The error is always printed only for `rosidl_typesupport_cpp`, and I haven't been able to determine why it doesn't also appear at times for other type supports, or why it doesn't happen all the time.

Any input on uncovering these answers is of course welcome, but since the condition seems to be benign (even if only from empirical observation), I would like to downgrade the errors to reduce their intrusiveness.
