### PR TITLE
Static type support for rosidl_typesupport_c

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -2,6 +2,8 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_typesupport_c)
 
+option(ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT "Enable static typesupport" OFF)
+
 # Default to C11
 if(NOT CMAKE_C_STANDARD)
   set(CMAKE_C_STANDARD 11)
@@ -16,13 +18,17 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake_ros REQUIRED)
-find_package(rcpputils REQUIRED)
 find_package(rcutils REQUIRED)
 find_package(rosidl_runtime_c REQUIRED)
+if(NOT ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT)
+  find_package(rcpputils REQUIRED)
+endif()
 
-ament_export_dependencies(rcpputils)
 ament_export_dependencies(rosidl_runtime_c)
 ament_export_dependencies(rosidl_typesupport_interface)
+if(NOT ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT)
+  ament_export_dependencies(rcpputils)
+endif()
 
 ament_export_include_directories(include)
 
@@ -36,15 +42,23 @@ if(WIN32)
   target_compile_definitions(${PROJECT_NAME}
     PRIVATE "ROSIDL_TYPESUPPORT_C_BUILDING_DLL")
 endif()
+target_compile_definitions(${PROJECT_NAME}
+  PRIVATE
+    $<$<BOOL:${ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT}>:ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT>
+)
 target_include_directories(${PROJECT_NAME} PUBLIC
   "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>"
   "$<INSTALL_INTERFACE:include>")
 
 ament_target_dependencies(${PROJECT_NAME}
-  "rcpputils"
   "rcutils"
   "rosidl_runtime_c"
 )
+if(NOT ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT)
+  ament_target_dependencies(${PROJECT_NAME}
+    "rcpputils"
+  )
+endif()
 ament_export_libraries(${PROJECT_NAME})
 ament_export_targets(${PROJECT_NAME})
 

--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -2,7 +2,19 @@ cmake_minimum_required(VERSION 3.5)
 
 project(rosidl_typesupport_c)
 
-option(ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT "Enable static typesupport" OFF)
+if(BUILD_SHARED_LIBS)
+  set(${PROJECT_NAME}_LIBRARY_TYPE "SHARED")
+else()
+  set(${PROJECT_NAME}_LIBRARY_TYPE "STATIC")
+endif()
+
+if(rosidl_typesupport_c_LIBRARY_TYPE STREQUAL "STATIC"
+  AND NOT BUILD_TESTING
+)
+  set(ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT ON)
+else()
+  set(ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT OFF)
+endif()
 
 # Default to C11
 if(NOT CMAKE_C_STANDARD)
@@ -139,12 +151,6 @@ if(BUILD_TESTING)
     target_link_libraries(benchmark_type_support_dispatch ${PROJECT_NAME})
     ament_target_dependencies(benchmark_type_support_dispatch rcpputils)
   endif()
-endif()
-
-if(BUILD_SHARED_LIBS)
-  set(${PROJECT_NAME}_LIBRARY_TYPE "SHARED")
-else()
-  set(${PROJECT_NAME}_LIBRARY_TYPE "STATIC")
 endif()
 
 ament_package(

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -119,17 +119,19 @@ target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
 # if only a single typesupport is used this package will directly reference it
 # therefore it needs to link against the selected typesupport
 if(NOT typesupports MATCHES ";")
+  set(SINGLE_TYPE_SUPPORT ON)
   target_include_directories(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     PUBLIC
     "$<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/${typesupports}>")
   target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${rosidl_generate_interfaces_TARGET}__${typesupports})
 else()
+  set(SINGLE_TYPE_SUPPORT OFF)
   if("${rosidl_typesupport_c_LIBRARY_TYPE}" STREQUAL "STATIC")
-  target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    PRIVATE
-    ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
-  )
+    target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+      PRIVATE
+      ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
+    )
   endif()
 endif()
 
@@ -157,13 +159,28 @@ add_dependencies(
 )
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)
-  install(
-    TARGETS ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin
-  )
+  if(SINGLE_TYPE_SUPPORT)
+    install(
+      TARGETS
+        ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+        ${rosidl_generate_interfaces_TARGET}__${typesupports}
+      EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+    )
+  else()
+    install(
+      TARGETS
+        ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+      EXPORT ${rosidl_generate_interfaces_TARGET}${_target_suffix}
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+    )
+  endif()
+
+
   ament_export_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix})
   ament_export_targets(${rosidl_generate_interfaces_TARGET}${_target_suffix})
 endif()

--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -126,8 +126,10 @@ if(NOT typesupports MATCHES ";")
     ${rosidl_generate_interfaces_TARGET}__${typesupports})
 else()
   if("${rosidl_typesupport_c_LIBRARY_TYPE}" STREQUAL "STATIC")
-    message(FATAL_ERROR "Multiple typesupports [${typesupports}] but static "
-      "linking was requested")
+  target_compile_definitions(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+    PRIVATE
+    ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
+  )
   endif()
 endif()
 
@@ -151,6 +153,7 @@ add_dependencies(
 add_dependencies(
   ${rosidl_generate_interfaces_TARGET}${_target_suffix}
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
+  ${rosidl_generate_interfaces_TARGET}__rosidl_typesupport_c
 )
 
 if(NOT rosidl_generate_interfaces_SKIP_INSTALL)

--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -76,6 +76,26 @@ typedef struct _@(message.structure.namespaced_type.name)_type_support_data_t
   void * data[@(len(type_supports))];
 } _@(message.structure.namespaced_type.name)_type_support_data_t;
 
+#ifdef ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+@[for type_support in sorted(type_supports)]@
+rosidl_message_type_support_t * ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(@(type_support), @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(message.structure.namespaced_type.name))();
+@[end for]@
+#ifdef __cplusplus
+}
+#endif
+
+static _@(message.structure.namespaced_type.name)_type_support_data_t _@(message.structure.namespaced_type.name)_message_typesupport_data = {
+  {
+@[for type_support in sorted(type_supports)]@
+    (void*) ROSIDL_TYPESUPPORT_INTERFACE__MESSAGE_SYMBOL_NAME(@(type_support), @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(message.structure.namespaced_type.name)),
+@[end for]@
+  }
+};
+#else
 static _@(message.structure.namespaced_type.name)_type_support_data_t _@(message.structure.namespaced_type.name)_message_typesupport_data = {
   {
 @[for type_support in sorted(type_supports)]@
@@ -83,6 +103,7 @@ static _@(message.structure.namespaced_type.name)_type_support_data_t _@(message
 @[end for]@
   }
 };
+#endif // ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
 
 static const type_support_map_t _@(message.structure.namespaced_type.name)_message_typesupport_map = {
   @(len(type_supports)),

--- a/rosidl_typesupport_c/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/srv__type_support.cpp.em
@@ -84,6 +84,26 @@ typedef struct _@(service.namespaced_type.name)_type_support_data_t
   void * data[@(len(type_supports))];
 } _@(service.namespaced_type.name)_type_support_data_t;
 
+#ifdef ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+@[for type_support in sorted(type_supports)]@
+rosidl_service_type_support_t * ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(@(type_support), @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name))();
+@[end for]@
+#ifdef __cplusplus
+}
+#endif
+
+static _@(service.namespaced_type.name)_type_support_data_t _@(service.namespaced_type.name)_service_typesupport_data = {
+  {
+@[for type_support in sorted(type_supports)]@
+    (void*) ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(@(type_support), @(', '.join([package_name] + list(interface_path.parents[0].parts))), @(service.namespaced_type.name)),
+@[end for]@
+  }
+};
+#else
 static _@(service.namespaced_type.name)_type_support_data_t _@(service.namespaced_type.name)_service_typesupport_data = {
   {
 @[for type_support in sorted(type_supports)]@
@@ -91,6 +111,7 @@ static _@(service.namespaced_type.name)_type_support_data_t _@(service.namespace
 @[end for]@
   }
 };
+#endif // ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
 
 static const type_support_map_t _@(service.namespaced_type.name)_service_typesupport_map = {
   @(len(type_supports)),

--- a/rosidl_typesupport_c/src/dynamic_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/dynamic_support_dispatch.hpp
@@ -1,0 +1,102 @@
+// Copyright 2021 Open Source Robotics Foundation, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DYNAMIC_SUPPORT_DISPATCH_HPP_
+#define DYNAMIC_SUPPORT_DISPATCH_HPP_
+
+#include <cstddef>
+#include <cstdio>
+#include <cstring>
+
+#include <memory>
+#include <stdexcept>
+#include <list>
+#include <string>
+
+#include "rcpputils/shared_library.hpp"
+#include "rcutils/error_handling.h"
+#include "rcutils/snprintf.h"
+#include "rosidl_typesupport_c/type_support_map.h"
+
+namespace rosidl_typesupport_c
+{
+
+static void *
+handle_shared_library_from_name(
+  const type_support_map_t * map,
+  size_t map_item,
+  const char * identifier
+)
+{
+  rcpputils::SharedLibrary * lib = nullptr;
+
+  if (!map->data[map_item]) {
+    char library_basename[1024];
+    int ret = rcutils_snprintf(
+      library_basename, 1023, "%s__%s",
+      map->package_name, identifier);
+    if (ret < 0) {
+      RCUTILS_SET_ERROR_MSG("Failed to format library name");
+      return nullptr;
+    }
+
+    std::string library_name;
+    try {
+      library_name = rcpputils::get_platform_library_name(library_basename);
+    } catch (const std::exception & e) {
+      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Failed to compute library name for '%s' due to %s",
+        library_basename, e.what());
+      return nullptr;
+    }
+
+    try {
+      lib = new rcpputils::SharedLibrary(library_name);
+    } catch (const std::runtime_error & e) {
+      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Could not load library %s: %s", library_name.c_str(), e.what());
+      return nullptr;
+    } catch (const std::bad_alloc & e) {
+      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Could not load library %s: %s", library_name.c_str(), e.what());
+      return nullptr;
+    }
+    map->data[map_item] = lib;
+  }
+
+  auto clib = static_cast<const rcpputils::SharedLibrary *>(map->data[map_item]);
+  lib = const_cast<rcpputils::SharedLibrary *>(clib);
+
+  void * sym = nullptr;
+
+  try {
+    if (!lib->has_symbol(map->symbol_name[map_item])) {
+      RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+        "Failed to find symbol '%s' in library", map->symbol_name[map_item]);
+      return nullptr;
+    }
+    sym = lib->get_symbol(map->symbol_name[map_item]);
+  } catch (const std::exception & e) {
+    RCUTILS_SET_ERROR_MSG_WITH_FORMAT_STRING(
+      "Failed to get symbol '%s' in library: %s",
+      map->symbol_name[map_item], e.what());
+    return nullptr;
+  }
+
+  return sym;
+}
+
+}  // namespace rosidl_typesupport_c
+
+#endif  // DYNAMIC_SUPPORT_DISPATCH_HPP_

--- a/rosidl_typesupport_c/src/type_support_dispatch.hpp
+++ b/rosidl_typesupport_c/src/type_support_dispatch.hpp
@@ -15,6 +15,8 @@
 #ifndef TYPE_SUPPORT_DISPATCH_HPP_
 #define TYPE_SUPPORT_DISPATCH_HPP_
 
+#ifndef ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
+
 #include <cstddef>
 #include <cstdio>
 #include <cstring>
@@ -24,6 +26,9 @@
 #include <string>
 
 #include "rcpputils/shared_library.hpp"
+
+#endif  // ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
+
 #include "rcutils/error_handling.h"
 #include "rcutils/snprintf.h"
 #include "rosidl_typesupport_c/identifier.h"
@@ -50,6 +55,8 @@ get_typesupport_handle_function(
       if (strcmp(map->typesupport_identifier[i], identifier) != 0) {
         continue;
       }
+      typedef const TypeSupport * (* funcSignature)(void);
+#ifndef ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
       rcpputils::SharedLibrary * lib = nullptr;
 
       if (!map->data[i]) {
@@ -103,9 +110,10 @@ get_typesupport_handle_function(
           map->symbol_name[i], e.what());
         return nullptr;
       }
-
-      typedef const TypeSupport * (* funcSignature)(void);
       funcSignature func = reinterpret_cast<funcSignature>(sym);
+#else
+      funcSignature func = reinterpret_cast<funcSignature>(map->data[i]);
+#endif  // ROSIDL_TYPESUPPORT_STATIC_TYPESUPPORT
       const TypeSupport * ts = func();
       return ts;
     }


### PR DESCRIPTION
Hello @sloretz and @clalancette,

here at micro-ROS, we are wondering if it is possible to implement the changes proposed here to allow `rosidl_typesupport_c` to have some kind of statically linked typesupport dispatch for those environments where dynamic library are not allowed (embedded).

Can we discuss this feature here? What are your opinions? 

CC: @ralph-lange @JanStaschulat 