### PR TITLE
Fix C and C++ typesupports CLI extensions

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -125,6 +125,9 @@ if(BUILD_TESTING)
     target_link_libraries(benchmark_type_support_dispatch ${PROJECT_NAME})
     ament_target_dependencies(benchmark_type_support_dispatch rcpputils)
   endif()
+
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_cli_extension test/test_cli_extension.py)
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/rosidl_typesupport_c/rosidl_typesupport_c/cli.py
+++ b/rosidl_typesupport_c/rosidl_typesupport_c/cli.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import pathlib
 
 from ament_index_python import get_package_share_directory
 from ament_index_python import get_resources
@@ -36,10 +36,10 @@ class GenerateCTypesupport(GenerateCommandExtension):
     ):
         generated_files = []
 
-        package_share_path = \
-            get_package_share_directory('rosidl_typesupport_c')
+        package_share_path = pathlib.Path(
+            get_package_share_directory('rosidl_typesupport_c'))
 
-        templates_path = os.path.join(package_share_path, 'resource')
+        templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
         idl_interface_files = []

--- a/rosidl_typesupport_c/test/msg/Test.msg
+++ b/rosidl_typesupport_c/test/msg/Test.msg
@@ -1,0 +1,1 @@
+string test

--- a/rosidl_typesupport_c/test/test_cli_extension.py
+++ b/rosidl_typesupport_c/test/test_cli_extension.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from rosidl_cli.command.generate.api import generate
+
+TEST_DIR = str(pathlib.Path(__file__).parent)
+
+
+def test_cli_extension_for_smoke(tmp_path):
+    generate(
+        package_name='rosidl_typesupport_c',
+        interface_files=[TEST_DIR + ':msg/Test.msg'],
+        typesupports=['c'],
+        output_path=tmp_path
+    )

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -121,6 +121,9 @@ if(BUILD_TESTING)
     target_link_libraries(benchmark_type_support_dispatch ${PROJECT_NAME})
     ament_target_dependencies(benchmark_type_support_dispatch rcpputils)
   endif()
+
+  find_package(ament_cmake_pytest REQUIRED)
+  ament_add_pytest_test(test_cli_extension test/test_cli_extension.py)
 endif()
 
 if(BUILD_SHARED_LIBS)

--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp/cli.py
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp/cli.py
@@ -12,13 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import pathlib
 
 from ament_index_python import get_package_share_directory
 from ament_index_python import get_resources
 
 from rosidl_cli.command.generate.extensions import GenerateCommandExtension
-from rosidl_cli.command.generate.helpers import legacy_generator_arguments_file
+from rosidl_cli.command.helpers import legacy_generator_arguments_file
 from rosidl_cli.command.translate.api import translate
 
 from rosidl_typesupport_cpp import generate_cpp
@@ -33,10 +33,10 @@ class GenerateCppTypesupport(GenerateCommandExtension):
         include_paths,
         output_path
     ):
-        package_share_path = \
-            get_package_share_directory('rosidl_typesupport_cpp')
+        package_share_path = pathlib.Path(
+            get_package_share_directory('rosidl_typesupport_cpp'))
 
-        templates_path = os.path.join(package_share_path, 'resource')
+        templates_path = package_share_path / 'resource'
 
         # Normalize interface definition format to .idl
         idl_interface_files = []

--- a/rosidl_typesupport_cpp/test/msg/Test.msg
+++ b/rosidl_typesupport_cpp/test/msg/Test.msg
@@ -1,0 +1,1 @@
+string test

--- a/rosidl_typesupport_cpp/test/test_cli_extension.py
+++ b/rosidl_typesupport_cpp/test/test_cli_extension.py
@@ -1,0 +1,28 @@
+# Copyright 2021 Open Source Robotics Foundation, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pathlib
+
+from rosidl_cli.command.generate.api import generate
+
+TEST_DIR = str(pathlib.Path(__file__).parent)
+
+
+def test_cli_extension_for_smoke(tmp_path):
+    generate(
+        package_name='rosidl_typesupport_cpp',
+        interface_files=[TEST_DIR + ':msg/Test.msg'],
+        typesupports=['cpp'],
+        output_path=tmp_path
+    )


### PR DESCRIPTION
This fixes issues I overlooked in #104 and #105. It also adds smoke tests that I should've added back then. Changes should be backportable to Galactic.

CI up `rosidl_typesupport_c` and  `rosidl_typesupport_cpp`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14719)](http://ci.ros2.org/job/ci_linux/14719/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9471)](http://ci.ros2.org/job/ci_linux-aarch64/9471/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12386)](http://ci.ros2.org/job/ci_osx/12386/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14865)](http://ci.ros2.org/job/ci_windows/14865/)
