### PR TITLE
Support available typesupport specification in CLI extensions 

### DIFF
--- a/rosidl_typesupport_c/rosidl_typesupport_c/cli.py
+++ b/rosidl_typesupport_c/rosidl_typesupport_c/cli.py
@@ -27,6 +27,13 @@ from rosidl_typesupport_c import generate_c
 
 class GenerateCTypesupport(GenerateCommandExtension):
 
+    def __init__(self, name, *, typesupport_implementations=None):
+        super().__init__(name)
+        if typesupport_implementations is None:
+            typesupport_implementations = list(
+                get_resources('rosidl_typesupport_c'))
+        self.__typesupport_implementations = typesupport_implementations
+
     def generate(
         self,
         package_name,
@@ -76,9 +83,6 @@ class GenerateCTypesupport(GenerateCommandExtension):
         generated_files.append(visibility_control_file_path)
 
         # Generate typesupport code
-        typesupport_implementations = list(
-            get_resources('rosidl_typesupport_c'))
-
         with legacy_generator_arguments_file(
             package_name=package_name,
             interface_files=idl_interface_files,
@@ -88,7 +92,7 @@ class GenerateCTypesupport(GenerateCommandExtension):
         ) as path_to_arguments_file:
             generated_files.extend(generate_c(
                 path_to_arguments_file,
-                typesupport_implementations
+                self.__typesupport_implementations
             ))
 
         return generated_files

--- a/rosidl_typesupport_c/test/test_cli_extension.py
+++ b/rosidl_typesupport_c/test/test_cli_extension.py
@@ -14,15 +14,19 @@
 
 import pathlib
 
+from ament_index_python import get_resources
 from rosidl_cli.command.generate.api import generate
 
 TEST_DIR = str(pathlib.Path(__file__).parent)
 
 
 def test_cli_extension_for_smoke(tmp_path):
+    ts = 'c[typesupport_implementations:{}]'.format(
+        list(get_resources('rosidl_typesupport_c'))
+    )
     generate(
         package_name='rosidl_typesupport_c',
         interface_files=[TEST_DIR + ':msg/Test.msg'],
-        typesupports=['c'],
+        typesupports=[ts],
         output_path=tmp_path
     )

--- a/rosidl_typesupport_c/test/test_cli_extension.py
+++ b/rosidl_typesupport_c/test/test_cli_extension.py
@@ -20,13 +20,28 @@ from rosidl_cli.command.generate.api import generate
 TEST_DIR = str(pathlib.Path(__file__).parent)
 
 
-def test_cli_extension_for_smoke(tmp_path):
-    ts = 'c[typesupport_implementations:{}]'.format(
-        list(get_resources('rosidl_typesupport_c'))
-    )
-    generate(
-        package_name='rosidl_typesupport_c',
-        interface_files=[TEST_DIR + ':msg/Test.msg'],
-        typesupports=[ts],
-        output_path=tmp_path
-    )
+def test_cli_extension_for_smoke(tmp_path, capsys):
+    # NOTE(hidmic): pytest and empy do not play along,
+    # the latter expects some proxy will stay in sys.stdout
+    # and the former insists in overwriting it
+    interface_files = [TEST_DIR + ':msg/Test.msg']
+
+    with capsys.disabled():  # so do everything in one run
+        # Passing target typesupport implementations explictly
+        ts = 'c[typesupport_implementations:{}]'.format(
+            list(get_resources('rosidl_typesupport_c'))
+        )
+        generate(
+            package_name='rosidl_typesupport_c',
+            interface_files=interface_files,
+            typesupports=[ts],
+            output_path=tmp_path / 'explicit_args'
+        )
+
+        # Using default typesupport implementations
+        generate(
+            package_name='rosidl_typesupport_c',
+            interface_files=interface_files,
+            typesupports=['c'],
+            output_path=tmp_path / 'defaults'
+        )

--- a/rosidl_typesupport_cpp/rosidl_typesupport_cpp/cli.py
+++ b/rosidl_typesupport_cpp/rosidl_typesupport_cpp/cli.py
@@ -26,6 +26,13 @@ from rosidl_typesupport_cpp import generate_cpp
 
 class GenerateCppTypesupport(GenerateCommandExtension):
 
+    def __init__(self, name, *, typesupport_implementations=None):
+        super().__init__(name)
+        if typesupport_implementations is None:
+            typesupport_implementations = list(
+                get_resources('rosidl_typesupport_cpp'))
+        self.__typesupport_implementations = typesupport_implementations
+
     def generate(
         self,
         package_name,
@@ -56,9 +63,6 @@ class GenerateCppTypesupport(GenerateCommandExtension):
             ))
 
         # Generate typesupport code
-        typesupport_implementations = list(
-            get_resources('rosidl_typesupport_cpp'))
-
         with legacy_generator_arguments_file(
             package_name=package_name,
             interface_files=idl_interface_files,
@@ -68,5 +72,5 @@ class GenerateCppTypesupport(GenerateCommandExtension):
         ) as path_to_arguments_file:
             return generate_cpp(
                 path_to_arguments_file,
-                typesupport_implementations
+                self.__typesupport_implementations
             )

--- a/rosidl_typesupport_cpp/test/test_cli_extension.py
+++ b/rosidl_typesupport_cpp/test/test_cli_extension.py
@@ -14,15 +14,19 @@
 
 import pathlib
 
+from ament_index_python import get_resources
 from rosidl_cli.command.generate.api import generate
 
 TEST_DIR = str(pathlib.Path(__file__).parent)
 
 
 def test_cli_extension_for_smoke(tmp_path):
+    ts = 'cpp[typesupport_implementations:{}]'.format(
+        list(get_resources('rosidl_typesupport_cpp'))
+    )
     generate(
         package_name='rosidl_typesupport_cpp',
         interface_files=[TEST_DIR + ':msg/Test.msg'],
-        typesupports=['cpp'],
+        typesupports=[ts],
         output_path=tmp_path
     )

--- a/rosidl_typesupport_cpp/test/test_cli_extension.py
+++ b/rosidl_typesupport_cpp/test/test_cli_extension.py
@@ -20,13 +20,28 @@ from rosidl_cli.command.generate.api import generate
 TEST_DIR = str(pathlib.Path(__file__).parent)
 
 
-def test_cli_extension_for_smoke(tmp_path):
-    ts = 'cpp[typesupport_implementations:{}]'.format(
-        list(get_resources('rosidl_typesupport_cpp'))
-    )
-    generate(
-        package_name='rosidl_typesupport_cpp',
-        interface_files=[TEST_DIR + ':msg/Test.msg'],
-        typesupports=[ts],
-        output_path=tmp_path
-    )
+def test_cli_extension_for_smoke(tmp_path, capsys):
+    # NOTE(hidmic): pytest and empy do not play along,
+    # the latter expects some proxy will stay in sys.stdout
+    # and the former insists in overwriting it
+    interface_files = [TEST_DIR + ':msg/Test.msg']
+
+    with capsys.disabled():  # so do everything in one run
+        # Passing target typesupport implementations explictly
+        ts = 'cpp[typesupport_implementations:{}]'.format(
+            list(get_resources('rosidl_typesupport_cpp'))
+        )
+        generate(
+            package_name='rosidl_typesupport_cpp',
+            interface_files=interface_files,
+            typesupports=[ts],
+            output_path=tmp_path / 'explicit_args'
+        )
+
+        # Using default typesupport implementations
+        generate(
+            package_name='rosidl_typesupport_cpp',
+            interface_files=interface_files,
+            typesupports=['cpp'],
+            output_path=tmp_path / 'defaults'
+        )


### PR DESCRIPTION
This patch allows the list of available typesupports to be narrowed down prior to generating C and C++ dynamic typesupport loading data structure through the `rosidl` CLI. Depends on https://github.com/ros2/rosidl/pull/597. Built on top of #111.

CI up to `rosidl_typesupport_c` and `rosidl_typesupport_cpp`:

CI up `rosidl_cli`, `rosidl_typesupport_c`, `rosidl_typesupport_cpp`, and `rosidl_generator_py`:

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=14724)](http://ci.ros2.org/job/ci_linux/14724/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=9476)](http://ci.ros2.org/job/ci_linux-aarch64/9476/)
* macOS [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_osx&build=12391)](http://ci.ros2.org/job/ci_osx/12391/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=14870)](http://ci.ros2.org/job/ci_windows/14870/)
