### PR TITLE
Use FindPython3 in typesupport packages

### DIFF
--- a/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_c/cmake/rosidl_typesupport_c_generate_interfaces.cmake
@@ -68,10 +68,13 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 get_used_typesupports(typesupports "rosidl_typesupport_c")
 add_custom_command(
   OUTPUT ${_generated_sources}
-  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_c_BIN}
+  COMMAND Python3::Interpreter
+  ARGS ${rosidl_typesupport_c_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   --typesupports ${typesupports}
   DEPENDS ${target_dependencies}

--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -11,6 +11,8 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <depend>rcpputils</depend>
   <depend>rcutils</depend>
 

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -68,10 +68,13 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
 )
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 get_used_typesupports(typesupports "rosidl_typesupport_cpp")
 add_custom_command(
   OUTPUT ${_generated_sources}
-  COMMAND ${PYTHON_EXECUTABLE} ${rosidl_typesupport_cpp_BIN}
+  COMMAND Python3::Interpreter
+  ARGS ${rosidl_typesupport_cpp_BIN}
   --generator-arguments-file "${generator_arguments_file}"
   --typesupports ${typesupports}
   DEPENDS ${target_dependencies}

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -11,6 +11,8 @@
 
   <buildtool_depend>ament_cmake_ros</buildtool_depend>
 
+  <buildtool_export_depend>python3</buildtool_export_depend>
+
   <depend>rcpputils</depend>
   <build_depend>rosidl_runtime_c</build_depend>
   <build_depend>rosidl_typesupport_c</build_depend>


### PR DESCRIPTION
Alternative to https://github.com/ros2/rosidl/pull/615


I think with both https://github.com/ament/ament_cmake/pull/355 and https://github.com/ros2/rosidl/pull/612 being merged yesterday, two sources of packages internally calling `find_package(PythonInterp)` got removed, but their CI's were run at different times. This replaces the implicit `PythonInterp` dependency with an explicit finding of `Python3`.