### PR TITLE
Make sure to check typesupport handles against nullptr properly.

### DIFF
--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -102,7 +102,7 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
-  ASSERT_TRUE(nullptr != lib);
+  ASSERT_NE(lib, nullptr);
 
   EXPECT_TRUE(lib->has_symbol("test_message_type_support"));
   auto * sym = lib->get_symbol("test_message_type_support");

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -102,7 +102,7 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
   ASSERT_NE(support_map.data[0], nullptr);
   auto * clib = static_cast<const rcpputils::SharedLibrary *>(support_map.data[0]);
   auto * lib = const_cast<rcpputils::SharedLibrary *>(clib);
-  ASSERT_TRUE(nullptr != lib);
+  ASSERT_NE(lib, nullptr);
 
   EXPECT_TRUE(lib->has_symbol("test_service_type_support"));
   auto * sym = lib->get_symbol("test_service_type_support");


### PR DESCRIPTION
clang has a false-positive warning where it can't figure out
that ASSERT_TRUE(foo != nullptr) means that the rest of the
test is safe to dereference foo.  Switching to ASSERT_NE(foo, nullptr)
fixes the issue, so do that here.  This should get rid of a
number of warnings when building under clang static analysis.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>