### PR TITLE
[service introspection] Guard `#include <cstddef>` when being included from a `c` source

### DIFF
--- a/rosidl_typesupport_c/include/rosidl_typesupport_c/type_support_map.h
+++ b/rosidl_typesupport_c/include/rosidl_typesupport_c/type_support_map.h
@@ -15,7 +15,9 @@
 #ifndef ROSIDL_TYPESUPPORT_C__TYPE_SUPPORT_MAP_H_
 #define ROSIDL_TYPESUPPORT_C__TYPE_SUPPORT_MAP_H_
 
+#ifdef __cplusplus
 #include <cstddef>
+#endif
 
 #ifdef __cplusplus
 extern "C"

--- a/rosidl_typesupport_c/include/rosidl_typesupport_c/type_support_map.h
+++ b/rosidl_typesupport_c/include/rosidl_typesupport_c/type_support_map.h
@@ -15,9 +15,7 @@
 #ifndef ROSIDL_TYPESUPPORT_C__TYPE_SUPPORT_MAP_H_
 #define ROSIDL_TYPESUPPORT_C__TYPE_SUPPORT_MAP_H_
 
-#ifdef __cplusplus
-#include <cstddef>
-#endif
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C"


### PR DESCRIPTION
This PR is a prototype for the service introspection REP (https://github.com/ros-infrastructure/rep/pull/360) implementing the proposed single serialized message approach (https://github.com/ros-infrastructure/rep/pull/360#discussion_r902987531).

This PR wraps `#include <cstddef>` in `rosidl_typesupport_c/include/rosidl_typesupport_c/type_support_map.h` so that `rcl` can access `type_support_map_t` 

See: https://github.com/ros2/rcl/pull/990

For instructions on how to build and run this see the meta-ticket https://github.com/ros2/ros2/issues/1285.


Resolves https://github.com/ros2/ros2/issues/1285
