### PR TITLE
Make rosidl_typesupport_tests depend on rosidl_generator_cpp.

### DIFF
--- a/rosidl_typesupport_tests/CMakeLists.txt
+++ b/rosidl_typesupport_tests/CMakeLists.txt
@@ -14,6 +14,7 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
   find_package(test_interface_files REQUIRED)
   find_package(rcutils REQUIRED)
+  find_package(rosidl_generator_cpp REQUIRED)
 
   rosidl_generate_interfaces(${PROJECT_NAME}
     ${test_interface_files_MSG_FILES}

--- a/rosidl_typesupport_tests/package.xml
+++ b/rosidl_typesupport_tests/package.xml
@@ -15,6 +15,7 @@
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>rcutils</test_depend>
   <test_depend>rosidl_cmake</test_depend>
+  <test_depend>rosidl_generator_cpp</test_depend>
   <test_depend>rosidl_typesupport_c</test_depend>
   <test_depend>rosidl_typesupport_cpp</test_depend>
   <test_depend>test_interface_files</test_depend>


### PR DESCRIPTION
Otherwise, when building it just for RMWs with introspection it fails to build saying it needs rosidl_generator_cpp.

Signed-off-by: Chris Lalancette <clalancette@openrobotics.org>

Goes along with https://github.com/ros2/rosidl/pull/724 , and fixes the issue in https://github.com/ros2/ros2/issues/1285#issuecomment-1419791566