### PR TITLE
Fix Typesupport Introspection tests

### DIFF
--- a/rosidl_typesupport_tests/CMakeLists.txt
+++ b/rosidl_typesupport_tests/CMakeLists.txt
@@ -8,15 +8,16 @@ endif()
 find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-  find_package(rosidl_cmake REQUIRED)
   find_package(ament_cmake_gtest REQUIRED)
-  find_package(test_interface_files REQUIRED)
+  find_package(ament_lint_auto REQUIRED)
   find_package(rcutils REQUIRED)
-  find_package(rosidl_generator_cpp REQUIRED)
   find_package(rmw REQUIRED)
   find_package(rmw_implementation REQUIRED)
+  find_package(rosidl_cmake REQUIRED)
+  find_package(rosidl_generator_cpp REQUIRED)
+  find_package(test_interface_files REQUIRED)
+
+  ament_lint_auto_find_test_dependencies()
 
   rosidl_generate_interfaces(${PROJECT_NAME}
     ${test_interface_files_MSG_FILES}
@@ -33,6 +34,8 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_service_typesupport_cpp
     "${cpp_typesupport_target}"
+    rmw::rmw
+    rmw_implementation::rmw_implementation
   )
 
   ament_add_gtest(test_service_typesupport_c
@@ -40,15 +43,8 @@ if(BUILD_TESTING)
   )
   target_link_libraries(test_service_typesupport_c
     "${c_typesupport_target}"
-  )
-
-  ament_target_dependencies(test_service_typesupport_cpp
-    rmw
-    rmw_implementation
-  )
-  ament_target_dependencies(test_service_typesupport_c
-    rmw
-    rmw_implementation
+    rmw::rmw
+    rmw_implementation::rmw_implementation
   )
 endif()
 

--- a/rosidl_typesupport_tests/CMakeLists.txt
+++ b/rosidl_typesupport_tests/CMakeLists.txt
@@ -16,6 +16,7 @@ if(BUILD_TESTING)
   find_package(rcutils REQUIRED)
   find_package(rosidl_generator_cpp REQUIRED)
   find_package(rmw REQUIRED)
+  find_package(rmw_implementation REQUIRED)
 
   rosidl_generate_interfaces(${PROJECT_NAME}
     ${test_interface_files_MSG_FILES}

--- a/rosidl_typesupport_tests/CMakeLists.txt
+++ b/rosidl_typesupport_tests/CMakeLists.txt
@@ -42,8 +42,14 @@ if(BUILD_TESTING)
     "${c_typesupport_target}"
   )
 
-  ament_target_dependencies(test_service_typesupport_cpp rmw)
-  ament_target_dependencies(test_service_typesupport_c rmw)
+  ament_target_dependencies(test_service_typesupport_cpp
+    rmw
+    rmw_implementation
+  )
+  ament_target_dependencies(test_service_typesupport_c
+    rmw
+    rmw_implementation
+  )
 endif()
 
 ament_package()

--- a/rosidl_typesupport_tests/CMakeLists.txt
+++ b/rosidl_typesupport_tests/CMakeLists.txt
@@ -15,6 +15,7 @@ if(BUILD_TESTING)
   find_package(test_interface_files REQUIRED)
   find_package(rcutils REQUIRED)
   find_package(rosidl_generator_cpp REQUIRED)
+  find_package(rmw REQUIRED)
 
   rosidl_generate_interfaces(${PROJECT_NAME}
     ${test_interface_files_MSG_FILES}
@@ -39,6 +40,9 @@ if(BUILD_TESTING)
   target_link_libraries(test_service_typesupport_c
     "${c_typesupport_target}"
   )
+
+  ament_target_dependencies(test_service_typesupport_cpp rmw)
+  ament_target_dependencies(test_service_typesupport_c rmw)
 endif()
 
 ament_package()

--- a/rosidl_typesupport_tests/package.xml
+++ b/rosidl_typesupport_tests/package.xml
@@ -22,6 +22,7 @@
   <test_depend>service_msgs</test_depend>
   <test_depend>action_msgs</test_depend>
   <test_depend>rmw</test_depend>
+  <test_depend>rmw_implementation</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosidl_typesupport_tests/package.xml
+++ b/rosidl_typesupport_tests/package.xml
@@ -10,19 +10,19 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
 
+  <test_depend>action_msgs</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>ament_lint_common</test_depend>
   <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>rcutils</test_depend>
+  <test_depend>rmw</test_depend>
+  <test_depend>rmw_implementation</test_depend>
   <test_depend>rosidl_cmake</test_depend>
   <test_depend>rosidl_generator_cpp</test_depend>
   <test_depend>rosidl_typesupport_c</test_depend>
   <test_depend>rosidl_typesupport_cpp</test_depend>
-  <test_depend>test_interface_files</test_depend>
   <test_depend>service_msgs</test_depend>
-  <test_depend>action_msgs</test_depend>
-  <test_depend>rmw</test_depend>
-  <test_depend>rmw_implementation</test_depend>
+  <test_depend>test_interface_files</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosidl_typesupport_tests/package.xml
+++ b/rosidl_typesupport_tests/package.xml
@@ -21,6 +21,7 @@
   <test_depend>test_interface_files</test_depend>
   <test_depend>service_msgs</test_depend>
   <test_depend>action_msgs</test_depend>
+  <test_depend>rmw</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
@@ -51,8 +51,10 @@ TEST(test_service_typesupport, basic_types_event_message_create)
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__srv__BasicTypes_Event();  // NOLINT
 
-  EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_introspection_c");
-  EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_c");
+  EXPECT_STREQ(srv_ts->typesupport_identifier,
+		  "rosidl_typesupport_introspection_c");
+  EXPECT_STREQ(msg_ts->typesupport_identifier,
+		  "rosidl_typesupport_introspection_c");
 
   EXPECT_EQ(srv_ts->event_typesupport, msg_ts);
 
@@ -177,6 +179,8 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__action__Fibonacci_GetResult_Event();  // NOLINT
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
-  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_c");
-  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_c");
+  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier,
+		  "rosidl_typesupport_introspection_c");
+  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier,
+		  "rosidl_typesupport_introspection_c");
 }

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
@@ -177,6 +177,6 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__action__Fibonacci_GetResult_Event();  // NOLINT
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
-  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_c");
-  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_c");
+  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_c");
+  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_c");
 }

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
@@ -55,7 +55,7 @@ TEST(test_service_typesupport, basic_types_event_message_create)
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__srv__BasicTypes_Event();  // NOLINT
 
-  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds")) {
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == 0) {
     EXPECT_STREQ(
       srv_ts->typesupport_identifier,
       "rosidl_typesupport_introspection_c");
@@ -184,7 +184,6 @@ TEST(test_service_typesupport, basic_types_event_message_create)
 
 TEST(test_service_typesupport, fibonacci_action_services_event)
 {
-
   const rosidl_message_type_support_t * send_goal_event_msg_ts =
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__action__Fibonacci_SendGoal_Event();  // NOLINT
   const rosidl_message_type_support_t * get_result_event_msg_ts =
@@ -192,7 +191,7 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
 
-  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds")) {
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == 0) {
     EXPECT_STREQ(
       send_goal_event_msg_ts->typesupport_identifier,
       "rosidl_typesupport_introspection_c");

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
@@ -12,12 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string.h>
 #include <algorithm>
 #include <array>
 
 #include "gtest/gtest.h"
 
 #include "rcutils/allocator.h"
+#include "rcutils/env.h"
 
 #include "rosidl_runtime_c/string_functions.h"
 
@@ -51,10 +53,22 @@ TEST(test_service_typesupport, basic_types_event_message_create)
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__srv__BasicTypes_Event();  // NOLINT
 
-  EXPECT_STREQ(srv_ts->typesupport_identifier,
-		  "rosidl_typesupport_introspection_c");
-  EXPECT_STREQ(msg_ts->typesupport_identifier,
-		  "rosidl_typesupport_introspection_c");
+  const char * expected_rmw_impl_env = NULL;
+  rcutils_get_env(
+    "RMW_IMPLEMENTATION",
+    &expected_rmw_impl_env);
+
+  if (strcmp(expected_rmw_impl_env, "rmw_cyclonedds_cpp") == 0) {
+    EXPECT_STREQ(
+      srv_ts->typesupport_identifier,
+      "rosidl_typesupport_introspection_c");
+    EXPECT_STREQ(
+      msg_ts->typesupport_identifier,
+      "rosidl_typesupport_introspection_c");
+  } else {
+    EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_c");
+    EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_c");
+  }
 
   EXPECT_EQ(srv_ts->event_typesupport, msg_ts);
 
@@ -173,14 +187,27 @@ TEST(test_service_typesupport, basic_types_event_message_create)
 
 TEST(test_service_typesupport, fibonacci_action_services_event)
 {
+  const char * expected_rmw_impl_env = NULL;
+  rcutils_get_env(
+    "RMW_IMPLEMENTATION",
+    &expected_rmw_impl_env);
+
   const rosidl_message_type_support_t * send_goal_event_msg_ts =
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__action__Fibonacci_SendGoal_Event();  // NOLINT
   const rosidl_message_type_support_t * get_result_event_msg_ts =
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__action__Fibonacci_GetResult_Event();  // NOLINT
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
-  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier,
-		  "rosidl_typesupport_introspection_c");
-  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier,
-		  "rosidl_typesupport_introspection_c");
+
+  if (strcmp(expected_rmw_impl_env, "rmw_cyclonedds_cpp") == 0) {
+    EXPECT_STREQ(
+      send_goal_event_msg_ts->typesupport_identifier,
+      "rosidl_typesupport_introspection_c");
+    EXPECT_STREQ(
+      get_result_event_msg_ts->typesupport_identifier,
+      "rosidl_typesupport_introspection_c");
+  } else {
+    EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_c");
+    EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_c");
+  }
 }

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
 #include <algorithm>
 #include <array>
+#include <string>
 
 #include "gtest/gtest.h"
 

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string.h>
+#include <string>
 #include <algorithm>
 #include <array>
 
@@ -25,6 +25,8 @@
 
 #include "rosidl_typesupport_tests/action/fibonacci.h"
 #include "rosidl_typesupport_tests/srv/basic_types.h"
+
+#include "rmw/rmw.h"
 
 TEST(test_service_typesupport, event_message_create_and_destroy_invalid_arguments)
 {
@@ -53,12 +55,7 @@ TEST(test_service_typesupport, basic_types_event_message_create)
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__srv__BasicTypes_Event();  // NOLINT
 
-  const char * expected_rmw_impl_env = NULL;
-  rcutils_get_env(
-    "RMW_IMPLEMENTATION",
-    &expected_rmw_impl_env);
-
-  if (strcmp(expected_rmw_impl_env, "rmw_cyclonedds_cpp") == 0) {
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds")) {
     EXPECT_STREQ(
       srv_ts->typesupport_identifier,
       "rosidl_typesupport_introspection_c");
@@ -187,10 +184,6 @@ TEST(test_service_typesupport, basic_types_event_message_create)
 
 TEST(test_service_typesupport, fibonacci_action_services_event)
 {
-  const char * expected_rmw_impl_env = NULL;
-  rcutils_get_env(
-    "RMW_IMPLEMENTATION",
-    &expected_rmw_impl_env);
 
   const rosidl_message_type_support_t * send_goal_event_msg_ts =
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__action__Fibonacci_SendGoal_Event();  // NOLINT
@@ -199,7 +192,7 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
 
-  if (strcmp(expected_rmw_impl_env, "rmw_cyclonedds_cpp") == 0) {
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds")) {
     EXPECT_STREQ(
       send_goal_event_msg_ts->typesupport_identifier,
       "rosidl_typesupport_introspection_c");

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
@@ -51,8 +51,8 @@ TEST(test_service_typesupport, basic_types_event_message_create)
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__srv__BasicTypes_Event();  // NOLINT
 
-  EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_c");
-  EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_c");
+  EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_introspection_c");
+  EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_c");
 
   EXPECT_EQ(srv_ts->event_typesupport, msg_ts);
 

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
@@ -181,6 +181,6 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
     rosidl_typesupport_tests::action::Fibonacci_GetResult::Event>();
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
-  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
-  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
+  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_cpp");
+  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_cpp");
 }

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
@@ -57,8 +57,10 @@ TEST(test_service_typesupport, basic_types_event_message_create)
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_cpp::get_message_type_support_handle<rosidl_typesupport_tests::srv::BasicTypes_Event>();  // NOLINT
 
-  EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_introspection_cpp");
-  EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_cpp");
+  EXPECT_STREQ(srv_ts->typesupport_identifier,
+		  "rosidl_typesupport_introspection_cpp");
+  EXPECT_STREQ(msg_ts->typesupport_identifier,
+		  "rosidl_typesupport_introspection_cpp");
 
   // typesupports are static so this comparison *should* be valid?
   EXPECT_EQ(srv_ts->event_typesupport, msg_ts);
@@ -181,6 +183,8 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
     rosidl_typesupport_tests::action::Fibonacci_GetResult::Event>();
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
-  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_cpp");
-  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_cpp");
+  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, 
+		  "rosidl_typesupport_introspection_cpp");
+  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier,
+		  "rosidl_typesupport_introspection_cpp");
 }

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string>
 #include <algorithm>
 #include <array>
 #include <stdexcept>
+#include <string>
 
 #include "gtest/gtest.h"
 

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <string.h>
+#include <string>
 #include <algorithm>
 #include <array>
 #include <stdexcept>
@@ -20,13 +20,14 @@
 #include "gtest/gtest.h"
 
 #include "rcutils/allocator.h"
-#include "rcutils/env.h"
 
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
 #include "rosidl_typesupport_cpp/service_type_support.hpp"
 
 #include "rosidl_typesupport_tests/action/fibonacci.hpp"
 #include "rosidl_typesupport_tests/srv/basic_types.hpp"
+
+#include "rmw/rmw.h"
 
 TEST(test_service_typesupport, event_message_create_and_destroy_invalid_arguments)
 {
@@ -58,13 +59,8 @@ TEST(test_service_typesupport, basic_types_event_message_create)
 
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_cpp::get_message_type_support_handle<rosidl_typesupport_tests::srv::BasicTypes_Event>();  // NOLINT
-
-  const char * expected_rmw_impl_env = NULL;
-  rcutils_get_env(
-    "RMW_IMPLEMENTATION",
-    &expected_rmw_impl_env);
-
-  if (strcmp(expected_rmw_impl_env, "rmw_cyclonedds_cpp") == 0) {
+														 //
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds")) {
     EXPECT_STREQ(
       srv_ts->typesupport_identifier,
       "rosidl_typesupport_introspection_cpp");
@@ -189,11 +185,6 @@ TEST(test_service_typesupport, basic_types_event_message_create)
 
 TEST(test_service_typesupport, fibonacci_action_services_event)
 {
-  const char * expected_rmw_impl_env = NULL;
-  rcutils_get_env(
-    "RMW_IMPLEMENTATION",
-    &expected_rmw_impl_env);
-
   const rosidl_message_type_support_t * send_goal_event_msg_ts =
     rosidl_typesupport_cpp::get_message_type_support_handle<
     rosidl_typesupport_tests::action::Fibonacci_SendGoal::Event>();
@@ -202,8 +193,7 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
     rosidl_typesupport_tests::action::Fibonacci_GetResult::Event>();
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
-
-  if (strcmp(expected_rmw_impl_env, "rmw_cyclonedds_cpp") == 0) {
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds")) {
     EXPECT_STREQ(
       send_goal_event_msg_ts->typesupport_identifier,
       "rosidl_typesupport_introspection_cpp");

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
@@ -57,8 +57,8 @@ TEST(test_service_typesupport, basic_types_event_message_create)
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_cpp::get_message_type_support_handle<rosidl_typesupport_tests::srv::BasicTypes_Event>();  // NOLINT
 
-  EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_cpp");
-  EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
+  EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_introspection_cpp");
+  EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_introspection_cpp");
 
   // typesupports are static so this comparison *should* be valid?
   EXPECT_EQ(srv_ts->event_typesupport, msg_ts);

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <string.h>
 #include <algorithm>
 #include <array>
 #include <stdexcept>
@@ -19,6 +20,7 @@
 #include "gtest/gtest.h"
 
 #include "rcutils/allocator.h"
+#include "rcutils/env.h"
 
 #include "rosidl_typesupport_cpp/message_type_support.hpp"
 #include "rosidl_typesupport_cpp/service_type_support.hpp"
@@ -57,10 +59,22 @@ TEST(test_service_typesupport, basic_types_event_message_create)
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_cpp::get_message_type_support_handle<rosidl_typesupport_tests::srv::BasicTypes_Event>();  // NOLINT
 
-  EXPECT_STREQ(srv_ts->typesupport_identifier,
-		  "rosidl_typesupport_introspection_cpp");
-  EXPECT_STREQ(msg_ts->typesupport_identifier,
-		  "rosidl_typesupport_introspection_cpp");
+  const char * expected_rmw_impl_env = NULL;
+  rcutils_get_env(
+    "RMW_IMPLEMENTATION",
+    &expected_rmw_impl_env);
+
+  if (strcmp(expected_rmw_impl_env, "rmw_cyclonedds_cpp") == 0) {
+    EXPECT_STREQ(
+      srv_ts->typesupport_identifier,
+      "rosidl_typesupport_introspection_cpp");
+    EXPECT_STREQ(
+      msg_ts->typesupport_identifier,
+      "rosidl_typesupport_introspection_cpp");
+  } else {
+    EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_cpp");
+    EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
+  }
 
   // typesupports are static so this comparison *should* be valid?
   EXPECT_EQ(srv_ts->event_typesupport, msg_ts);
@@ -175,6 +189,11 @@ TEST(test_service_typesupport, basic_types_event_message_create)
 
 TEST(test_service_typesupport, fibonacci_action_services_event)
 {
+  const char * expected_rmw_impl_env = NULL;
+  rcutils_get_env(
+    "RMW_IMPLEMENTATION",
+    &expected_rmw_impl_env);
+
   const rosidl_message_type_support_t * send_goal_event_msg_ts =
     rosidl_typesupport_cpp::get_message_type_support_handle<
     rosidl_typesupport_tests::action::Fibonacci_SendGoal::Event>();
@@ -183,8 +202,16 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
     rosidl_typesupport_tests::action::Fibonacci_GetResult::Event>();
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
-  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, 
-		  "rosidl_typesupport_introspection_cpp");
-  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier,
-		  "rosidl_typesupport_introspection_cpp");
+
+  if (strcmp(expected_rmw_impl_env, "rmw_cyclonedds_cpp") == 0) {
+    EXPECT_STREQ(
+      send_goal_event_msg_ts->typesupport_identifier,
+      "rosidl_typesupport_introspection_cpp");
+    EXPECT_STREQ(
+      get_result_event_msg_ts->typesupport_identifier,
+      "rosidl_typesupport_introspection_cpp");
+  } else {
+    EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
+    EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
+  }
 }

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
@@ -59,8 +59,8 @@ TEST(test_service_typesupport, basic_types_event_message_create)
 
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_cpp::get_message_type_support_handle<rosidl_typesupport_tests::srv::BasicTypes_Event>();  // NOLINT
-														 //
-  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds")) {
+
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == 0) {
     EXPECT_STREQ(
       srv_ts->typesupport_identifier,
       "rosidl_typesupport_introspection_cpp");
@@ -193,7 +193,7 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
     rosidl_typesupport_tests::action::Fibonacci_GetResult::Event>();
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
-  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds")) {
+  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == 0) {
     EXPECT_STREQ(
       send_goal_event_msg_ts->typesupport_identifier,
       "rosidl_typesupport_introspection_cpp");


### PR DESCRIPTION
Signed-off-by: Crola1702 <cristobal.arroyo@ekumenlabs.com>

After (https://github.com/ros2/rosidl_typesupport/pull/127) we have new 2 failing tests in Rolling CycloneDDS:

[projectroot.test_service_typesupport_cpp](https://build.ros2.org/view/Rci/job/Rci__nightly-cyclonedds_ubuntu_jammy_amd64/351/testReport/junit/(root)/projectroot/test_service_typesupport_cpp/) log output:
<details>

```
-- run_test.py: invoking following command in '/tmp/ws/build_isolated/rosidl_typesupport_tests':
 - /tmp/ws/build_isolated/rosidl_typesupport_tests/test_service_typesupport_cpp --gtest_output=xml:/tmp/ws/test_results/rosidl_typesupport_tests/test_service_typesupport_cpp.gtest.xml
Running main() from /tmp/ws/install_isolated/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from test_service_typesupport
[ RUN      ] test_service_typesupport.event_message_create_and_destroy_invalid_arguments
[       OK ] test_service_typesupport.event_message_create_and_destroy_invalid_arguments (0 ms)
[ RUN      ] test_service_typesupport.basic_types_event_message_create
/tmp/ws/src/ros2/rosidl_typesupport/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp:60: Failure
Expected equality of these values:
  srv_ts->typesupport_identifier
    Which is: "rosidl_typesupport_introspection_cpp"
  "rosidl_typesupport_cpp"
/tmp/ws/src/ros2/rosidl_typesupport/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp:61: Failure
Expected equality of these values:
  msg_ts->typesupport_identifier
    Which is: "rosidl_typesupport_introspection_cpp"
  "rosidl_typesupport_cpp"
[  FAILED  ] test_service_typesupport.basic_types_event_message_create (0 ms)
[ RUN      ] test_service_typesupport.fibonacci_action_services_event
/tmp/ws/src/ros2/rosidl_typesupport/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp:184: Failure
Expected equality of these values:
  send_goal_event_msg_ts->typesupport_identifier
    Which is: "rosidl_typesupport_introspection_cpp"
  "rosidl_typesupport_cpp"
/tmp/ws/src/ros2/rosidl_typesupport/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp:185: Failure
Expected equality of these values:
  get_result_event_msg_ts->typesupport_identifier
    Which is: "rosidl_typesupport_introspection_cpp"
  "rosidl_typesupport_cpp"
[  FAILED  ] test_service_typesupport.fibonacci_action_services_event (0 ms)
[----------] 3 tests from test_service_typesupport (0 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] test_service_typesupport.basic_types_event_message_create
[  FAILED  ] test_service_typesupport.fibonacci_action_services_event

 2 FAILED TESTS
-- run_test.py: return code 1
-- run_test.py: inject classname prefix into gtest result file '/tmp/ws/test_results/rosidl_typesupport_tests/test_service_typesupport_cpp.gtest.xml'
-- run_test.py: verify result file '/tmp/ws/test_results/rosidl_typesupport_tests/test_service_typesupport_cpp.gtest.xml'
```

</details>

[projectroot.test_service_typesupport_c](https://build.ros2.org/view/Rci/job/Rci__nightly-cyclonedds_ubuntu_jammy_amd64/351/testReport/junit/(root)/projectroot/test_service_typesupport_c/) log output:
<details>

```
-- run_test.py: invoking following command in '/tmp/ws/build_isolated/rosidl_typesupport_tests':
 - /tmp/ws/build_isolated/rosidl_typesupport_tests/test_service_typesupport_c --gtest_output=xml:/tmp/ws/test_results/rosidl_typesupport_tests/test_service_typesupport_c.gtest.xml
Running main() from /tmp/ws/install_isolated/gtest_vendor/src/gtest_vendor/src/gtest_main.cc
[==========] Running 3 tests from 1 test suite.
[----------] Global test environment set-up.
[----------] 3 tests from test_service_typesupport
[ RUN      ] test_service_typesupport.event_message_create_and_destroy_invalid_arguments
[       OK ] test_service_typesupport.event_message_create_and_destroy_invalid_arguments (0 ms)
[ RUN      ] test_service_typesupport.basic_types_event_message_create
/tmp/ws/src/ros2/rosidl_typesupport/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp:54: Failure
Expected equality of these values:
  srv_ts->typesupport_identifier
    Which is: "rosidl_typesupport_introspection_c"
  "rosidl_typesupport_c"
/tmp/ws/src/ros2/rosidl_typesupport/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp:55: Failure
Expected equality of these values:
  msg_ts->typesupport_identifier
    Which is: "rosidl_typesupport_introspection_c"
  "rosidl_typesupport_c"
[  FAILED  ] test_service_typesupport.basic_types_event_message_create (0 ms)
[ RUN      ] test_service_typesupport.fibonacci_action_services_event
/tmp/ws/src/ros2/rosidl_typesupport/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp:180: Failure
Expected equality of these values:
  send_goal_event_msg_ts->typesupport_identifier
    Which is: "rosidl_typesupport_introspection_c"
  "rosidl_typesupport_c"
/tmp/ws/src/ros2/rosidl_typesupport/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp:181: Failure
Expected equality of these values:
  get_result_event_msg_ts->typesupport_identifier
    Which is: "rosidl_typesupport_introspection_c"
  "rosidl_typesupport_c"
[  FAILED  ] test_service_typesupport.fibonacci_action_services_event (0 ms)
[----------] 3 tests from test_service_typesupport (0 ms total)

[----------] Global test environment tear-down
[==========] 3 tests from 1 test suite ran. (0 ms total)
[  PASSED  ] 1 test.
[  FAILED  ] 2 tests, listed below:
[  FAILED  ] test_service_typesupport.basic_types_event_message_create
[  FAILED  ] test_service_typesupport.fibonacci_action_services_event

 2 FAILED TESTS
-- run_test.py: return code 1
-- run_test.py: inject classname prefix into gtest result file '/tmp/ws/test_results/rosidl_typesupport_tests/test_service_typesupport_c.gtest.xml'
-- run_test.py: verify result file '/tmp/ws/test_results/rosidl_typesupport_tests/test_service_typesupport_c.gtest.xml'
```

</details>

Reference build: https://build.ros2.org/view/Rci/job/Rci__nightly-cyclonedds_ubuntu_jammy_amd64/351/#showFailuresLink

This PR changes the expected `typesupport_identifier` so it matches the actual value.