### PR TITLE
Type hashes in typesupport (rep2011)

### DIFF
--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -1,6 +1,7 @@
 @# Included from rosidl_typesupport_c/resource/idl__type_support.c.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -98,7 +99,7 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   rosidl_typesupport_c__typesupport_identifier,
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   rosidl_typesupport_c__get_message_typesupport_handle_function,
-  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__TYPE_VERSION_HASH,
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_HASH_VAR),
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -1,5 +1,6 @@
 @# Included from rosidl_typesupport_c/resource/idl__type_support.c.em
 @{
+from rosidl_generator_c import idl_structure_type_to_c_typename
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -97,6 +98,7 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   rosidl_typesupport_c__typesupport_identifier,
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   rosidl_typesupport_c__get_message_typesupport_handle_function,
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__TYPE_VERSION_HASH,
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/srv__type_support.cpp.em
@@ -24,6 +24,11 @@ TEMPLATE(
 }@
 
 @{
+from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_HASH_VAR
+from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
+from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
+from rosidl_parser.definition import SERVICE_RESPONSE_MESSAGE_SUFFIX
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -118,6 +123,8 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
   rosidl_typesupport_c__typesupport_identifier,
   reinterpret_cast<const type_support_map_t *>(&_@(service.namespaced_type.name)_service_typesupport_map),
   rosidl_typesupport_c__get_service_typesupport_handle_function,
+  &@(service.namespaced_type.name)@(SERVICE_REQUEST_MESSAGE_SUFFIX)_message_type_support_handle,
+  &@(service.namespaced_type.name)@(SERVICE_RESPONSE_MESSAGE_SUFFIX)_message_type_support_handle,
   ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_CREATE_EVENT_MESSAGE_SYMBOL_NAME(
     rosidl_typesupport_c,
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
@@ -126,7 +133,8 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
     rosidl_typesupport_c,
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
   ),
-  &@(service.namespaced_type.name)_Event_message_type_support_handle
+  &@(service.namespaced_type.name)@(SERVICE_EVENT_MESSAGE_SUFFIX)_message_type_support_handle,
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_HASH_VAR),
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/srv__type_support.cpp.em
@@ -125,6 +125,7 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
   rosidl_typesupport_c__get_service_typesupport_handle_function,
   &@(service.namespaced_type.name)@(SERVICE_REQUEST_MESSAGE_SUFFIX)_message_type_support_handle,
   &@(service.namespaced_type.name)@(SERVICE_RESPONSE_MESSAGE_SUFFIX)_message_type_support_handle,
+  &@(service.namespaced_type.name)@(SERVICE_EVENT_MESSAGE_SUFFIX)_message_type_support_handle,
   ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_CREATE_EVENT_MESSAGE_SYMBOL_NAME(
     rosidl_typesupport_c,
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
@@ -133,7 +134,6 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
     rosidl_typesupport_c,
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
   ),
-  &@(service.namespaced_type.name)@(SERVICE_EVENT_MESSAGE_SUFFIX)_message_type_support_handle,
   &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_HASH_VAR),
 };
 

--- a/rosidl_typesupport_c/test/benchmark/benchmark_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/benchmark/benchmark_type_support_dispatch.cpp
@@ -43,7 +43,7 @@ rosidl_message_type_support_t get_rosidl_message_type_support(const char * ident
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/benchmark/benchmark_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/benchmark/benchmark_type_support_dispatch.cpp
@@ -38,12 +38,12 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr};
 }
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -38,7 +38,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -38,7 +38,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -38,7 +38,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/test_type_support.c
+++ b/rosidl_typesupport_c/test/test_type_support.c
@@ -34,7 +34,7 @@ static const rosidl_message_type_support_t message_type_support = {
 };
 
 static const rosidl_service_type_support_t service_type_support = {
-  0, 0, 0, 0, 0, 0, 0
+  0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}

--- a/rosidl_typesupport_c/test/test_type_support.c
+++ b/rosidl_typesupport_c/test/test_type_support.c
@@ -30,11 +30,11 @@ const rosidl_service_type_support_t * test_service_type_support();
 #endif
 
 static const rosidl_message_type_support_t message_type_support = {
-  0, 0, 0
+  0, 0, 0, 0
 };
 
 static const rosidl_service_type_support_t service_type_support = {
-  0, 0, 0, 0, 0, 0
+  0, 0, 0, 0, 0, 0, 0
 };
 
 const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}

--- a/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
@@ -1,5 +1,6 @@
 @# Included from rosidl_typesupport_cpp/resource/idl__type_support.cpp.em
 @{
+from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -97,7 +98,7 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   ::rosidl_typesupport_cpp::typesupport_identifier,
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   ::rosidl_typesupport_cpp::get_message_typesupport_handle_function,
-  &@('::'.join(message.structure.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
+  &@('::'.join(message.structure.namespaced_type.namespaced_name()))::@(TYPE_HASH_VAR),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
@@ -97,6 +97,7 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   ::rosidl_typesupport_cpp::typesupport_identifier,
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   ::rosidl_typesupport_cpp::get_message_typesupport_handle_function,
+  &@('::'.join(message.structure.namespaced_type.namespaced_name()))::TYPE_VERSION_HASH,
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
@@ -24,6 +24,11 @@ TEMPLATE(
 }@
 
 @{
+from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_HASH_VAR
+from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
+from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
+from rosidl_parser.definition import SERVICE_RESPONSE_MESSAGE_SUFFIX
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -120,9 +125,12 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
   ::rosidl_typesupport_cpp::typesupport_identifier,
   reinterpret_cast<const type_support_map_t *>(&_@(service.namespaced_type.name)_service_typesupport_map),
   ::rosidl_typesupport_cpp::get_service_typesupport_handle_function,
+  ::rosidl_typesupport_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_REQUEST_MESSAGE_SUFFIX)>(),
+  ::rosidl_typesupport_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_RESPONSE_MESSAGE_SUFFIX)>(),
   &::rosidl_typesupport_cpp::service_create_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &::rosidl_typesupport_cpp::service_destroy_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
-  ::rosidl_typesupport_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))_Event>(),
+  ::rosidl_typesupport_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_EVENT_MESSAGE_SUFFIX)>(),
+  &@('::'.join((service.namespaced_type.namespaced_name())))::@(TYPE_HASH_VAR),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
@@ -127,9 +127,9 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
   ::rosidl_typesupport_cpp::get_service_typesupport_handle_function,
   ::rosidl_typesupport_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_REQUEST_MESSAGE_SUFFIX)>(),
   ::rosidl_typesupport_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_RESPONSE_MESSAGE_SUFFIX)>(),
+  ::rosidl_typesupport_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_EVENT_MESSAGE_SUFFIX)>(),
   &::rosidl_typesupport_cpp::service_create_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &::rosidl_typesupport_cpp::service_destroy_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
-  ::rosidl_typesupport_cpp::get_message_type_support_handle<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))@(SERVICE_EVENT_MESSAGE_SUFFIX)>(),
   &@('::'.join((service.namespaced_type.namespaced_name())))::@(TYPE_HASH_VAR),
 };
 

--- a/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
@@ -43,7 +43,7 @@ rosidl_message_type_support_t get_rosidl_message_type_support(const char * ident
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
@@ -38,12 +38,12 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr};
 }
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -35,7 +35,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -35,7 +35,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -35,7 +35,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_cpp/test/test_type_support.cpp
+++ b/rosidl_typesupport_cpp/test/test_type_support.cpp
@@ -39,7 +39,7 @@ static const rosidl_message_type_support_t message_type_support = {
 };
 
 static const rosidl_service_type_support_t service_type_support = {
-  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
 };
 
 const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}

--- a/rosidl_typesupport_cpp/test/test_type_support.cpp
+++ b/rosidl_typesupport_cpp/test/test_type_support.cpp
@@ -35,11 +35,11 @@ const rosidl_service_type_support_t * test_service_type_support();
 #endif
 
 static const rosidl_message_type_support_t message_type_support = {
-  nullptr, nullptr, nullptr
+  nullptr, nullptr, nullptr, nullptr
 };
 
 static const rosidl_service_type_support_t service_type_support = {
-  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
 };
 
 const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}


### PR DESCRIPTION
Depends on ros2/rosidl#729 (coupled - must be merged together)
Part of ros2/ros2#1159

Fill out new type_hash and message_type_support fields on generated `rosidl_message_type_support_t` and `rosidl_service_type_support_t` structs.
