### PR TITLE
Type Description Typesupport (rep2011)

### DIFF
--- a/rosidl_typesupport_c/resource/action__type_support.c.em
+++ b/rosidl_typesupport_c/resource/action__type_support.c.em
@@ -1,6 +1,7 @@
 @# Included from rosidl_typesupport_c/resource/idl__type_support.c.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import RAW_SOURCE_VAR
 from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import ACTION_FEEDBACK_MESSAGE_SUFFIX
@@ -36,6 +37,7 @@ static rosidl_action_type_support_t _@('__'.join([package_name] + list(interface
   NULL, NULL, NULL, NULL, NULL,
   &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_HASH_VAR),
   &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(RAW_SOURCE_VAR),
 };
 
 #ifdef __cplusplus

--- a/rosidl_typesupport_c/resource/action__type_support.c.em
+++ b/rosidl_typesupport_c/resource/action__type_support.c.em
@@ -1,8 +1,8 @@
 @# Included from rosidl_typesupport_c/resource/idl__type_support.c.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
-from rosidl_generator_type_description import RAW_SOURCE_VAR
-from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
+from rosidl_generator_type_description import GET_DESCRIPTION_FUNC
+from rosidl_generator_type_description import GET_SOURCES_FUNC
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import ACTION_FEEDBACK_MESSAGE_SUFFIX
 from rosidl_parser.definition import ACTION_GOAL_SERVICE_SUFFIX
@@ -36,8 +36,8 @@ header_files = (
 static rosidl_action_type_support_t _@('__'.join([package_name] + list(interface_path.parents[0].parts)))__@(interface_path.stem)__typesupport_c = {
   NULL, NULL, NULL, NULL, NULL,
   &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_HASH_VAR),
-  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
-  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(RAW_SOURCE_VAR),
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(GET_DESCRIPTION_FUNC),
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(GET_SOURCES_FUNC),
 };
 
 #ifdef __cplusplus

--- a/rosidl_typesupport_c/resource/action__type_support.c.em
+++ b/rosidl_typesupport_c/resource/action__type_support.c.em
@@ -1,5 +1,8 @@
 @# Included from rosidl_typesupport_c/resource/idl__type_support.c.em
 @{
+from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
+from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import ACTION_FEEDBACK_MESSAGE_SUFFIX
 from rosidl_parser.definition import ACTION_GOAL_SERVICE_SUFFIX
 from rosidl_parser.definition import ACTION_RESULT_SERVICE_SUFFIX
@@ -29,7 +32,11 @@ header_files = (
 #include "@(header_file)"
 @[end for]@
 
-static rosidl_action_type_support_t _@('__'.join([package_name] + list(interface_path.parents[0].parts)))__@(interface_path.stem)__typesupport_c;
+static rosidl_action_type_support_t _@('__'.join([package_name] + list(interface_path.parents[0].parts)))__@(interface_path.stem)__typesupport_c = {
+  NULL, NULL, NULL, NULL, NULL,
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_HASH_VAR),
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
+};
 
 #ifdef __cplusplus
 extern "C"

--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -96,18 +96,12 @@ static const type_support_map_t _@(message.structure.namespaced_type.name)_messa
   &_@(message.structure.namespaced_type.name)_message_typesupport_data.data[0],
 };
 
-static const rosidl_runtime_c__type_description__TypeDescription *
-_@(message.structure.namespaced_type.name)__get_type_description()
-{
-  return &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_DESCRIPTION_VAR);
-}
-
 static const rosidl_message_type_support_t @(message.structure.namespaced_type.name)_message_type_support_handle = {
   rosidl_typesupport_c__typesupport_identifier,
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   rosidl_typesupport_c__get_message_typesupport_handle_function,
   &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_HASH_VAR),
-  &_@(message.structure.namespaced_type.name)__get_type_description,
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -1,6 +1,7 @@
 @# Included from rosidl_typesupport_c/resource/idl__type_support.c.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import RAW_SOURCE_VAR
 from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
@@ -102,6 +103,7 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   rosidl_typesupport_c__get_message_typesupport_handle_function,
   &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_HASH_VAR),
   &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(RAW_SOURCE_VAR),
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -1,6 +1,7 @@
 @# Included from rosidl_typesupport_c/resource/idl__type_support.c.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
@@ -95,11 +96,18 @@ static const type_support_map_t _@(message.structure.namespaced_type.name)_messa
   &_@(message.structure.namespaced_type.name)_message_typesupport_data.data[0],
 };
 
+static const rosidl_runtime_c__type_description__TypeDescription *
+_@(message.structure.namespaced_type.name)__get_type_description()
+{
+  return &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_DESCRIPTION_VAR);
+}
+
 static const rosidl_message_type_support_t @(message.structure.namespaced_type.name)_message_type_support_handle = {
   rosidl_typesupport_c__typesupport_identifier,
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   rosidl_typesupport_c__get_message_typesupport_handle_function,
   &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_HASH_VAR),
+  &_@(message.structure.namespaced_type.name)__get_type_description,
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/msg__type_support.cpp.em
@@ -1,8 +1,8 @@
 @# Included from rosidl_typesupport_c/resource/idl__type_support.c.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
-from rosidl_generator_type_description import RAW_SOURCE_VAR
-from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
+from rosidl_generator_type_description import GET_DESCRIPTION_FUNC
+from rosidl_generator_type_description import GET_SOURCES_FUNC
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
@@ -102,8 +102,8 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   rosidl_typesupport_c__get_message_typesupport_handle_function,
   &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_HASH_VAR),
-  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
-  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(RAW_SOURCE_VAR),
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(GET_DESCRIPTION_FUNC),
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(GET_SOURCES_FUNC),
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/srv__type_support.cpp.em
@@ -25,8 +25,8 @@ TEMPLATE(
 
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
-from rosidl_generator_type_description import RAW_SOURCE_VAR
-from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
+from rosidl_generator_type_description import GET_DESCRIPTION_FUNC
+from rosidl_generator_type_description import GET_SOURCES_FUNC
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
@@ -137,8 +137,8 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
   ),
   &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_HASH_VAR),
-  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
-  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(RAW_SOURCE_VAR),
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(GET_DESCRIPTION_FUNC),
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(GET_SOURCES_FUNC),
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/srv__type_support.cpp.em
@@ -25,6 +25,7 @@ TEMPLATE(
 
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import RAW_SOURCE_VAR
 from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
@@ -137,6 +138,7 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
   ),
   &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_HASH_VAR),
   &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(RAW_SOURCE_VAR),
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_c/resource/srv__type_support.cpp.em
@@ -25,6 +25,7 @@ TEMPLATE(
 
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
@@ -135,6 +136,7 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
     @(',\n    '.join(service.namespaced_type.namespaced_name()))
   ),
   &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_HASH_VAR),
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
 };
 
 }  // namespace rosidl_typesupport_c

--- a/rosidl_typesupport_c/test/benchmark/benchmark_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/benchmark/benchmark_type_support_dispatch.cpp
@@ -38,12 +38,15 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {
+    identifier,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+  };
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/benchmark/benchmark_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/benchmark/benchmark_type_support_dispatch.cpp
@@ -38,12 +38,12 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr};
 }
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -38,7 +38,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -38,7 +38,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -39,7 +39,8 @@ constexpr const char * symbols[map_size] = {
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
   return {
-    identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+    identifier,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
   };
 }
 

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -38,7 +38,9 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {
+    identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+  };
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_c/test/test_type_support.c
+++ b/rosidl_typesupport_c/test/test_type_support.c
@@ -30,11 +30,11 @@ const rosidl_service_type_support_t * test_service_type_support();
 #endif
 
 static const rosidl_message_type_support_t message_type_support = {
-  0, 0, 0, 0, 0
+  0, 0, 0, 0, 0, 0
 };
 
 static const rosidl_service_type_support_t service_type_support = {
-  0, 0, 0, 0, 0, 0, 0, 0, 0, 0
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}

--- a/rosidl_typesupport_c/test/test_type_support.c
+++ b/rosidl_typesupport_c/test/test_type_support.c
@@ -30,11 +30,11 @@ const rosidl_service_type_support_t * test_service_type_support();
 #endif
 
 static const rosidl_message_type_support_t message_type_support = {
-  0, 0, 0, 0
+  0, 0, 0, 0, 0
 };
 
 static const rosidl_service_type_support_t service_type_support = {
-  0, 0, 0, 0, 0, 0, 0, 0, 0
+  0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
 const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}

--- a/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_cpp/cmake/rosidl_typesupport_cpp_generate_interfaces.cmake
@@ -116,6 +116,7 @@ endif()
 
 # Depend on the target created by rosidl_generator_cpp
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PUBLIC
+  ${rosidl_generate_interfaces_TARGET}__rosidl_generator_c
   ${rosidl_generate_interfaces_TARGET}__rosidl_generator_cpp)
 
 target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix} PRIVATE

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -35,6 +35,7 @@
 
   <exec_depend>ament_index_python</exec_depend>
   <exec_depend>rosidl_cli</exec_depend>
+  <exec_depend>rosidl_generator_c</exec_depend>
   <exec_depend>rosidl_generator_type_description</exec_depend>
   <exec_depend>rosidl_pycommon</exec_depend>
   <exec_depend>rosidl_typesupport_interface</exec_depend>

--- a/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
@@ -1,8 +1,8 @@
 @# Included from rosidl_typesupport_cpp/resource/idl__type_support.cpp.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
-from rosidl_generator_type_description import RAW_SOURCE_VAR
-from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
+from rosidl_generator_type_description import GET_DESCRIPTION_FUNC
+from rosidl_generator_type_description import GET_SOURCES_FUNC
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
@@ -42,8 +42,8 @@ namespace rosidl_typesupport_cpp
 static rosidl_action_type_support_t @(interface_path.stem)_action_type_support_handle = {
   NULL, NULL, NULL, NULL, NULL,
   &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_HASH_VAR),
-  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
-  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(RAW_SOURCE_VAR),
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(GET_DESCRIPTION_FUNC),
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(GET_SOURCES_FUNC),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
@@ -1,6 +1,7 @@
 @# Included from rosidl_typesupport_cpp/resource/idl__type_support.cpp.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import RAW_SOURCE_VAR
 from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
@@ -42,6 +43,7 @@ static rosidl_action_type_support_t @(interface_path.stem)_action_type_support_h
   NULL, NULL, NULL, NULL, NULL,
   &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_HASH_VAR),
   &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(RAW_SOURCE_VAR),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
@@ -1,5 +1,8 @@
 @# Included from rosidl_typesupport_cpp/resource/idl__type_support.cpp.em
 @{
+from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
+from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
     'detail', convert_camel_case_to_lower_case_underscore(interface_path.stem)]
@@ -36,7 +39,10 @@ namespace rosidl_typesupport_cpp
 {
 
 static rosidl_action_type_support_t @(interface_path.stem)_action_type_support_handle = {
-  NULL, NULL, NULL, NULL, NULL};
+  NULL, NULL, NULL, NULL, NULL,
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_HASH_VAR),
+  &@(idl_structure_type_to_c_typename(action.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
+};
 
 }  // namespace rosidl_typesupport_cpp
 @[  for ns in reversed(action.namespaced_type.namespaces)]@

--- a/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
@@ -99,6 +99,7 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   ::rosidl_typesupport_cpp::get_message_typesupport_handle_function,
   &@('::'.join(message.structure.namespaced_type.namespaced_name()))::@(TYPE_HASH_VAR),
+  nullptr, // TODO(ek)
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
@@ -1,6 +1,7 @@
 @# Included from rosidl_typesupport_cpp/resource/idl__type_support.cpp.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import RAW_SOURCE_VAR
 from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
@@ -103,6 +104,7 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   ::rosidl_typesupport_cpp::get_message_typesupport_handle_function,
   &@('::'.join(message.structure.namespaced_type.namespaced_name()))::@(TYPE_HASH_VAR),
   &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(RAW_SOURCE_VAR),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
@@ -1,5 +1,7 @@
 @# Included from rosidl_typesupport_cpp/resource/idl__type_support.cpp.em
 @{
+from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
@@ -9,6 +11,7 @@ include_base = '/'.join(include_parts)
 header_files = [
     'cstddef',
     'rosidl_runtime_c/message_type_support_struct.h',
+    include_base + '__struct.h',
     include_base + '__struct.hpp',
 ]
 if len(type_supports) != 1:
@@ -99,7 +102,7 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   ::rosidl_typesupport_cpp::get_message_typesupport_handle_function,
   &@('::'.join(message.structure.namespaced_type.namespaced_name()))::@(TYPE_HASH_VAR),
-  nullptr, // TODO(ek)
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/msg__type_support.cpp.em
@@ -1,8 +1,8 @@
 @# Included from rosidl_typesupport_cpp/resource/idl__type_support.cpp.em
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
-from rosidl_generator_type_description import RAW_SOURCE_VAR
-from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
+from rosidl_generator_type_description import GET_DESCRIPTION_FUNC
+from rosidl_generator_type_description import GET_SOURCES_FUNC
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_pycommon import convert_camel_case_to_lower_case_underscore
 include_parts = [package_name] + list(interface_path.parents[0].parts) + [
@@ -12,7 +12,7 @@ include_base = '/'.join(include_parts)
 header_files = [
     'cstddef',
     'rosidl_runtime_c/message_type_support_struct.h',
-    include_base + '__struct.h',
+    include_base + '__functions.h',
     include_base + '__struct.hpp',
 ]
 if len(type_supports) != 1:
@@ -103,8 +103,8 @@ static const rosidl_message_type_support_t @(message.structure.namespaced_type.n
   reinterpret_cast<const type_support_map_t *>(&_@(message.structure.namespaced_type.name)_message_typesupport_map),
   ::rosidl_typesupport_cpp::get_message_typesupport_handle_function,
   &@('::'.join(message.structure.namespaced_type.namespaced_name()))::@(TYPE_HASH_VAR),
-  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
-  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(RAW_SOURCE_VAR),
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(GET_DESCRIPTION_FUNC),
+  &@(idl_structure_type_to_c_typename(message.structure.namespaced_type))__@(GET_SOURCES_FUNC),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
@@ -25,6 +25,7 @@ TEMPLATE(
 
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import RAW_SOURCE_VAR
 from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
@@ -133,6 +134,7 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
   &::rosidl_typesupport_cpp::service_destroy_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &@('::'.join((service.namespaced_type.namespaced_name())))::@(TYPE_HASH_VAR),
   &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(RAW_SOURCE_VAR),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
@@ -25,6 +25,7 @@ TEMPLATE(
 
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
+from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
@@ -131,6 +132,7 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
   &::rosidl_typesupport_cpp::service_create_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &::rosidl_typesupport_cpp::service_destroy_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &@('::'.join((service.namespaced_type.namespaced_name())))::@(TYPE_HASH_VAR),
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
@@ -25,8 +25,8 @@ TEMPLATE(
 
 @{
 from rosidl_generator_c import idl_structure_type_to_c_typename
-from rosidl_generator_type_description import RAW_SOURCE_VAR
-from rosidl_generator_type_description import TYPE_DESCRIPTION_VAR
+from rosidl_generator_type_description import GET_DESCRIPTION_FUNC
+from rosidl_generator_type_description import GET_SOURCES_FUNC
 from rosidl_generator_type_description import TYPE_HASH_VAR
 from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
@@ -133,8 +133,8 @@ static const rosidl_service_type_support_t @(service.namespaced_type.name)_servi
   &::rosidl_typesupport_cpp::service_create_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &::rosidl_typesupport_cpp::service_destroy_event_message<@('::'.join([package_name, *interface_path.parents[0].parts, service.namespaced_type.name]))>,
   &@('::'.join((service.namespaced_type.namespaced_name())))::@(TYPE_HASH_VAR),
-  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(TYPE_DESCRIPTION_VAR),
-  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(RAW_SOURCE_VAR),
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(GET_DESCRIPTION_FUNC),
+  &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(GET_SOURCES_FUNC),
 };
 
 }  // namespace rosidl_typesupport_cpp

--- a/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
@@ -38,12 +38,14 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr};
 }
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {
+    identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+  };
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/benchmark/benchmark_type_support_dispatch.cpp
@@ -38,13 +38,14 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
   return {
-    identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+    identifier,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
   };
 }
 

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -35,7 +35,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_message_type_support_dispatch.cpp
@@ -35,7 +35,7 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_message_type_support_t get_rosidl_message_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr};
+  return {identifier, nullptr, nullptr, nullptr, nullptr};
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -35,7 +35,9 @@ constexpr const char * symbols[map_size] = {
 
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
-  return {identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr};
+  return {
+    identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+  };
 }
 
 type_support_map_t get_typesupport_map(void ** library_array)

--- a/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_cpp/test/test_service_type_support_dispatch.cpp
@@ -36,7 +36,8 @@ constexpr const char * symbols[map_size] = {
 rosidl_service_type_support_t get_rosidl_service_type_support(const char * identifier)
 {
   return {
-    identifier, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+    identifier,
+    nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
   };
 }
 

--- a/rosidl_typesupport_cpp/test/test_type_support.cpp
+++ b/rosidl_typesupport_cpp/test/test_type_support.cpp
@@ -35,11 +35,11 @@ const rosidl_service_type_support_t * test_service_type_support();
 #endif
 
 static const rosidl_message_type_support_t message_type_support = {
-  nullptr, nullptr, nullptr, nullptr
+  nullptr, nullptr, nullptr, nullptr, nullptr,
 };
 
 static const rosidl_service_type_support_t service_type_support = {
-  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
 };
 
 const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}

--- a/rosidl_typesupport_cpp/test/test_type_support.cpp
+++ b/rosidl_typesupport_cpp/test/test_type_support.cpp
@@ -35,11 +35,11 @@ const rosidl_service_type_support_t * test_service_type_support();
 #endif
 
 static const rosidl_message_type_support_t message_type_support = {
-  nullptr, nullptr, nullptr, nullptr, nullptr,
+  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
 };
 
 static const rosidl_service_type_support_t service_type_support = {
-  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
+  nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
 };
 
 const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}


### PR DESCRIPTION
Part of ros2/ros2#1159

Depends on https://github.com/ros2/rosidl/pull/727

Adds `type_description` and `type_description_sources` member definitions into `_type_support` structs.
Note: adds dependency on `rosidl_generator_c` to do so.