### PR TITLE
[humble backport] Added C interfaces to obtain service and action type support.

### DIFF
--- a/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/action__type_support.cpp.em
@@ -63,3 +63,18 @@ get_action_type_support_handle<@('::'.join([package_name] + list(interface_path.
 }
 
 }  // namespace rosidl_typesupport_cpp
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_CPP_PUBLIC
+const rosidl_action_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__ACTION_SYMBOL_NAME(rosidl_typesupport_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [interface_path.stem])))() {
+  return ::rosidl_typesupport_cpp::get_action_type_support_handle<@('::'.join([package_name] + list(interface_path.parents[0].parts) + [interface_path.stem]))>();
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
+++ b/rosidl_typesupport_cpp/resource/srv__type_support.cpp.em
@@ -153,3 +153,18 @@ get_service_type_support_handle<@('::'.join([package_name] + list(interface_path
 }
 
 }  // namespace rosidl_typesupport_cpp
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+ROSIDL_TYPESUPPORT_CPP_PUBLIC
+const rosidl_service_type_support_t *
+ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_SYMBOL_NAME(rosidl_typesupport_cpp, @(', '.join([package_name] + list(interface_path.parents[0].parts) + [service.namespaced_type.name])))() {
+  return ::rosidl_typesupport_cpp::get_service_type_support_handle<@('::'.join([package_name] + list(interface_path.parents[0].parts) + [service.namespaced_type.name]))>();
+}
+
+#ifdef __cplusplus
+}
+#endif


### PR DESCRIPTION
Backport of https://github.com/ros2/rosidl_typesupport/pull/143 for humble. See https://github.com/ros2/rosidl_typesupport/pull/114 for discussion.
Interfaces are declared in https://github.com/ros2/rosidl/pull/778