### PR TITLE
Fixed warnings - strict-prototypes

### DIFF
--- a/rosidl_typesupport_c/test/test_type_support.c
+++ b/rosidl_typesupport_c/test/test_type_support.c
@@ -37,6 +37,12 @@ static const rosidl_service_type_support_t service_type_support = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
-const rosidl_message_type_support_t * test_message_type_support(void) {return &message_type_support;}
+const rosidl_message_type_support_t * test_message_type_support(void)
+{
+  return &message_type_support;
+}
 
-const rosidl_service_type_support_t * test_service_type_support(void) {return &service_type_support;}
+const rosidl_service_type_support_t * test_service_type_support(void)
+{
+  return &service_type_support;
+}

--- a/rosidl_typesupport_c/test/test_type_support.c
+++ b/rosidl_typesupport_c/test/test_type_support.c
@@ -22,11 +22,11 @@
 // function still needs to be defined separately. Windows has gotten picky with its compiler
 // warnings recently.
 #if defined _WIN32 || defined __CYGWIN__
-__declspec(dllexport) const rosidl_message_type_support_t * test_message_type_support();
-__declspec(dllexport) const rosidl_service_type_support_t * test_service_type_support();
+__declspec(dllexport) const rosidl_message_type_support_t * test_message_type_support(void);
+__declspec(dllexport) const rosidl_service_type_support_t * test_service_type_support(void);
 #else
-const rosidl_message_type_support_t * test_message_type_support();
-const rosidl_service_type_support_t * test_service_type_support();
+const rosidl_message_type_support_t * test_message_type_support(void);
+const rosidl_service_type_support_t * test_service_type_support(void);
 #endif
 
 static const rosidl_message_type_support_t message_type_support = {
@@ -37,6 +37,6 @@ static const rosidl_service_type_support_t service_type_support = {
   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 };
 
-const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}
+const rosidl_message_type_support_t * test_message_type_support(void) {return &message_type_support;}
 
-const rosidl_service_type_support_t * test_service_type_support() {return &service_type_support;}
+const rosidl_service_type_support_t * test_service_type_support(void) {return &service_type_support;}

--- a/rosidl_typesupport_cpp/test/test_type_support.cpp
+++ b/rosidl_typesupport_cpp/test/test_type_support.cpp
@@ -27,8 +27,8 @@ extern "C"
 // function still needs to be defined separately. Windows has gotten picky with its compiler
 // warnings recently.
 #if defined _WIN32 || defined __CYGWIN__
-__declspec(dllexport) const rosidl_message_type_support_t * test_message_type_support(void);
-__declspec(dllexport) const rosidl_service_type_support_t * test_service_type_support(void);
+__declspec(dllexport) const rosidl_message_type_support_t * test_message_type_support();
+__declspec(dllexport) const rosidl_service_type_support_t * test_service_type_support();
 #else
 const rosidl_message_type_support_t * test_message_type_support(void);
 const rosidl_service_type_support_t * test_service_type_support(void);

--- a/rosidl_typesupport_cpp/test/test_type_support.cpp
+++ b/rosidl_typesupport_cpp/test/test_type_support.cpp
@@ -30,8 +30,8 @@ extern "C"
 __declspec(dllexport) const rosidl_message_type_support_t * test_message_type_support();
 __declspec(dllexport) const rosidl_service_type_support_t * test_service_type_support();
 #else
-const rosidl_message_type_support_t * test_message_type_support(void);
-const rosidl_service_type_support_t * test_service_type_support(void);
+const rosidl_message_type_support_t * test_message_type_support();
+const rosidl_service_type_support_t * test_service_type_support();
 #endif
 
 static const rosidl_message_type_support_t message_type_support = {
@@ -42,9 +42,9 @@ static const rosidl_service_type_support_t service_type_support = {
   nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
 };
 
-const rosidl_message_type_support_t * test_message_type_support(void) {return &message_type_support;}
+const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}
 
-const rosidl_service_type_support_t * test_service_type_support(void) {return &service_type_support;}
+const rosidl_service_type_support_t * test_service_type_support() {return &service_type_support;}
 
 #ifdef __cplusplus
 }

--- a/rosidl_typesupport_cpp/test/test_type_support.cpp
+++ b/rosidl_typesupport_cpp/test/test_type_support.cpp
@@ -27,11 +27,11 @@ extern "C"
 // function still needs to be defined separately. Windows has gotten picky with its compiler
 // warnings recently.
 #if defined _WIN32 || defined __CYGWIN__
-__declspec(dllexport) const rosidl_message_type_support_t * test_message_type_support();
-__declspec(dllexport) const rosidl_service_type_support_t * test_service_type_support();
+__declspec(dllexport) const rosidl_message_type_support_t * test_message_type_support(void);
+__declspec(dllexport) const rosidl_service_type_support_t * test_service_type_support(void);
 #else
-const rosidl_message_type_support_t * test_message_type_support();
-const rosidl_service_type_support_t * test_service_type_support();
+const rosidl_message_type_support_t * test_message_type_support(void);
+const rosidl_service_type_support_t * test_service_type_support(void);
 #endif
 
 static const rosidl_message_type_support_t message_type_support = {
@@ -42,9 +42,9 @@ static const rosidl_service_type_support_t service_type_support = {
   nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr, nullptr
 };
 
-const rosidl_message_type_support_t * test_message_type_support() {return &message_type_support;}
+const rosidl_message_type_support_t * test_message_type_support(void) {return &message_type_support;}
 
-const rosidl_service_type_support_t * test_service_type_support() {return &service_type_support;}
+const rosidl_service_type_support_t * test_service_type_support(void) {return &service_type_support;}
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
There are new warnings on CI related with this compiler option `strict-prototypes`

https://ci.ros2.org/view/nightly/job/nightly_linux_clang_libcxx/1860/gcc/new/