### PR TITLE
Add mechanism to disable workaround for dependency groups

### DIFF
--- a/rosidl_typesupport_c/package.xml
+++ b/rosidl_typesupport_c/package.xml
@@ -21,12 +21,9 @@
   <depend>rcutils</depend>
 
   <build_depend>rosidl_runtime_c</build_depend>
-  <!--
-  Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_c_packages.
-  This ensures that binary packages have support for all of these rmw impl. enabled.
-  -->
-  <build_depend>rosidl_typesupport_introspection_c</build_depend>
-  <!-- end of group rosidl_typesupport_c_packages for bloom -->
+
+  <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_introspection_c</build_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <build_export_depend>rosidl_runtime_c</build_export_depend>

--- a/rosidl_typesupport_cpp/package.xml
+++ b/rosidl_typesupport_cpp/package.xml
@@ -21,12 +21,9 @@
   <depend>rcpputils</depend>
   <build_depend>rosidl_runtime_c</build_depend>
   <build_depend>rosidl_typesupport_c</build_depend>
-  <!--
-  Bloom does not support group_depend so entries below duplicate the group rosidl_typesupport_cpp_packages.
-  This ensures that binary packages have support for all of these rmw impl. enabled.
-  -->
-  <build_depend>rosidl_typesupport_introspection_cpp</build_depend>
-  <!-- end of group rosidl_typesupport_cpp_packages for bloom -->
+
+  <!-- Explicit group resolution - see ros-infrastructure/catkin_pkg#369 -->
+  <build_depend condition="$DISABLE_GROUPS_WORKAROUND != 1">rosidl_typesupport_introspection_cpp</build_depend>
 
   <buildtool_export_depend>ament_cmake_core</buildtool_export_depend>
   <build_export_depend>rosidl_typesupport_c</build_export_depend>


### PR DESCRIPTION
See ros-infrastructure/catkin_pkg#369

* Linux [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux&build=20943)](http://ci.ros2.org/job/ci_linux/20943/)
* Linux-aarch64 [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_linux-aarch64&build=15234)](http://ci.ros2.org/job/ci_linux-aarch64/15234/)
* Windows [![Build Status](http://ci.ros2.org/buildStatus/icon?job=ci_windows&build=21617)](http://ci.ros2.org/job/ci_windows/21617/)