### PR TITLE
Cleanup warning message in rosidl_typesupport_c tests.

### DIFF
--- a/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_message_type_support_dispatch.cpp
@@ -104,6 +104,7 @@ TEST(TestMessageTypeSupportDispatch, get_handle_function) {
       rosidl_typesupport_c__get_message_typesupport_handle_function(
         &type_support_c_identifier,
         "test_type_support1"), nullptr);
+    rcutils_reset_error();
   }
 
   // Successfully load library and find symbols

--- a/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
+++ b/rosidl_typesupport_c/test/test_service_type_support_dispatch.cpp
@@ -107,6 +107,7 @@ TEST(TestServiceTypeSupportDispatch, get_handle_function) {
       rosidl_typesupport_c__get_service_typesupport_handle_function(
         &type_support_c_identifier,
         "test_type_support1"), nullptr);
+    rcutils_reset_error();
   }
 
   // Successfully load library and find symbols


### PR DESCRIPTION
Just to get rid of an ugly warning message.