### PR TITLE
Uniform cmake requirement

### DIFF
--- a/rosidl_typesupport_c/CMakeLists.txt
+++ b/rosidl_typesupport_c/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(rosidl_typesupport_c)
 

--- a/rosidl_typesupport_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_cpp/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.20)
 
 project(rosidl_typesupport_cpp)
 

--- a/rosidl_typesupport_tests/CMakeLists.txt
+++ b/rosidl_typesupport_tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20)
 project(rosidl_typesupport_tests)
 
 # Default to C++17


### PR DESCRIPTION
cmake <3.10 is deprecated.
Uniform minimum cmake version to the same version used in the rosidl_typesupport_cpp library