### PR TITLE
pass all tests for rmw_cyclonedds_cpp.

### DIFF
--- a/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_c/test_service_typesupport.cpp
@@ -59,17 +59,8 @@ TEST(test_service_typesupport, basic_types_event_message_create)
     rosidl_typesupport_c__get_message_type_support_handle__rosidl_typesupport_tests__srv__BasicTypes_Event();  // NOLINT
   // *INDENT-ON*
 
-  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == 0) {
-    EXPECT_STREQ(
-      srv_ts->typesupport_identifier,
-      "rosidl_typesupport_introspection_c");
-    EXPECT_STREQ(
-      msg_ts->typesupport_identifier,
-      "rosidl_typesupport_introspection_c");
-  } else {
-    EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_c");
-    EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_c");
-  }
+  EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_c");
+  EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_c");
 
   EXPECT_EQ(srv_ts->event_typesupport, msg_ts);
 
@@ -198,15 +189,6 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
 
-  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == 0) {
-    EXPECT_STREQ(
-      send_goal_event_msg_ts->typesupport_identifier,
-      "rosidl_typesupport_introspection_c");
-    EXPECT_STREQ(
-      get_result_event_msg_ts->typesupport_identifier,
-      "rosidl_typesupport_introspection_c");
-  } else {
-    EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_c");
-    EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_c");
-  }
+  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_c");
+  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_c");
 }

--- a/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
+++ b/rosidl_typesupport_tests/test/rosidl_typesupport_cpp/test_service_typesupport.cpp
@@ -60,17 +60,8 @@ TEST(test_service_typesupport, basic_types_event_message_create)
   const rosidl_message_type_support_t * msg_ts =
     rosidl_typesupport_cpp::get_message_type_support_handle<rosidl_typesupport_tests::srv::BasicTypes_Event>();  // NOLINT
 
-  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == 0) {
-    EXPECT_STREQ(
-      srv_ts->typesupport_identifier,
-      "rosidl_typesupport_introspection_cpp");
-    EXPECT_STREQ(
-      msg_ts->typesupport_identifier,
-      "rosidl_typesupport_introspection_cpp");
-  } else {
-    EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_cpp");
-    EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
-  }
+  EXPECT_STREQ(srv_ts->typesupport_identifier, "rosidl_typesupport_cpp");
+  EXPECT_STREQ(msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
 
   // typesupports are static so this comparison *should* be valid?
   EXPECT_EQ(srv_ts->event_typesupport, msg_ts);
@@ -193,15 +184,6 @@ TEST(test_service_typesupport, fibonacci_action_services_event)
     rosidl_typesupport_tests::action::Fibonacci_GetResult::Event>();
   ASSERT_NE(nullptr, send_goal_event_msg_ts);
   ASSERT_NE(nullptr, get_result_event_msg_ts);
-  if (std::string(rmw_get_implementation_identifier()).find("rmw_cyclonedds") == 0) {
-    EXPECT_STREQ(
-      send_goal_event_msg_ts->typesupport_identifier,
-      "rosidl_typesupport_introspection_cpp");
-    EXPECT_STREQ(
-      get_result_event_msg_ts->typesupport_identifier,
-      "rosidl_typesupport_introspection_cpp");
-  } else {
-    EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
-    EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
-  }
+  EXPECT_STREQ(send_goal_event_msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
+  EXPECT_STREQ(get_result_event_msg_ts->typesupport_identifier, "rosidl_typesupport_cpp");
 }


### PR DESCRIPTION
## Description

replaces https://github.com/ros2/rosidl_typesupport/pull/170 with extra fixes.
with this PR, `rmw_cyclonedds_cpp` can pass all the test with `colcon test --event-handlers console_direct+ --packages-select rosidl_typesupport_tests`

<!--
Please include a summary of the changes and the related issue.
Highlight any key points or areas of concern.
-->

<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.*
-->

Part of https://github.com/ros2/rmw_cyclonedds/pull/550

### Is this user-facing behavior change?

No

<!--
If no, just leave this section empty.
If yes, please explain how user-experience changes with this pull request.
-->

### Did you use Generative AI?

No

<!--
If this pull request was generated using Generative AI, please specify the tool and model used (e.g., GitHub Copilot, GPT-4.1).
If only specific parts were generated by Generative AI, please list those parts (e.g., function A, class B, etc.).
-->

### Additional Information

<!--
If applicable, provide any additional context or details about the changes.
-->
